### PR TITLE
Add tests for SqPath

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "errno-dragonfly"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +216,15 @@ checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
  "bit-set",
  "regex",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -350,13 +370,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -367,8 +396,8 @@ checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix",
- "windows-sys",
+ "rustix 0.36.8",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -403,6 +432,12 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "map-macro"
@@ -649,6 +684,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -713,11 +757,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
 dependencies = [
  "bitflags",
- "errno",
+ "errno 0.2.8",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
- "windows-sys",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b24138615de35e32031d041a09032ef3487a616d901ca4db224e7d557efae2"
+dependencies = [
+ "bitflags",
+ "errno 0.3.1",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.7",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -830,6 +888,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "syn",
+ "tempfile",
  "thiserror",
  "walkdir",
 ]
@@ -902,6 +961,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix 0.37.3",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1035,7 +1107,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -1044,13 +1125,28 @@ version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.1",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
+ "windows_x86_64_gnullvm 0.42.1",
+ "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -1060,10 +1156,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1072,10 +1180,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1084,16 +1204,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ rstest = "0.17"
 slyce = "0.3.1"
 strum = "0.24"
 strum_macros = "0.24"
+tempfile = "3.5"
 
 [build-dependencies]
 anyhow = "1.0.69"

--- a/src/system/schema.json
+++ b/src/system/schema.json
@@ -127,7 +127,24 @@
             "name": "SqOsString",
             "doc": "A string in the OS's encoding",
             "primitive_coercion": "PrimitiveString",
-            "fields": []
+            "fields": [
+                {
+                    "name": "string",
+                    "doc": "Convert to an SqString (a unicode string). Fails if the SqOsString is not valid unicode.",
+                    "return_type": "SqString",
+                    "return_sequence_type": "Single",
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "replace_invalid",
+                            "doc": "Replace invalid unicode bytes with � instead of failing.",
+                            "type": "PrimitiveBool",
+                            "required": false,
+                            "default_value": false
+                        }
+                    ]
+                }
+            ]
         },
         {
             "name": "SqPath",
@@ -139,7 +156,16 @@
                     "doc": "Get the path as an SqString",
                     "return_type": "SqString",
                     "return_sequence_type": "Single",
-                    "params": []
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "replace_invalid",
+                            "doc": "Replace invalid unicode bytes with � instead of failing.",
+                            "type": "PrimitiveBool",
+                            "required": false,
+                            "default_value": false
+                        }
+                    ]
                 },
                 {
                     "name": "os_string",
@@ -158,8 +184,8 @@
                         "* The parent of \"/home/user1/file.tar.gz\" is \"/home/user1\".",
                         "* The parent of \"/home/user1/.file\" is \"/home/user1\".",
                         "* The parent of \"/usr/bin/sq\" is \"/usr/bin\".",
-                        "* The parent of \"/usr/bin/\" is \"/usr/bin\".",
-                        "* The parent of \"/\" is \"/\"."
+                        "* The parent of \"/usr/bin/\" is \"/usr\".",
+                        "* The parent of \"/\" is null."
                     ],
                     "return_type": "SqPath",
                     "return_sequence_type": "Option",
@@ -175,8 +201,8 @@
                         "* The filename of \"/home/user1/file.tar.gz\" is \"file.tar.gz\".",
                         "* The filename of \"/home/user1/.file\" is \".file\".",
                         "* The filename of \"/usr/bin/sq\" is \"sq\".",
-                        "* The filename of \"/usr/bin/\" is \"\".",
-                        "* The filename of \"/\" is \"\"."
+                        "* The filename of \"/usr/bin/\" is \"bin\".",
+                        "* The filename of \"/\" is null."
                     ],
                     "return_type": "SqOsString",
                     "return_sequence_type": "Option",
@@ -193,8 +219,8 @@
                         "* The stem of \"/home/user1/file.tar.gz\" is \"file.tar\".",
                         "* The stem of \"/home/user1/.file\" is \".file\".",
                         "* The stem of \"/usr/bin/sq\" is \"sq\".",
-                        "* The stem of \"/usr/bin/\" is \"\".",
-                        "* The stem of \"/\" is \"\"."
+                        "* The stem of \"/usr/bin/\" is \"bin\".",
+                        "* The stem of \"/\" is null."
                     ],
                     "return_type": "SqOsString",
                     "return_sequence_type": "Option",
@@ -218,11 +244,11 @@
                         "  An exception is made for filenames whose only \".\" is at the start of the name:",
                         "  the extension of \"/home/user1/.bashrc\" is \"\", not \".bashrc\".",
                         "Examples:",
-                        "* The extension of \"/home/user1/file.tar.gz\" is \".gz\".",
-                        "* The extension of \"/home/user1/.file\" is \"\".",
-                        "* The extension of \"/usr/bin/sq\" is \"\".",
-                        "* The extension of \"/usr/bin/\" is \"\".",
-                        "* The extension of \"/\" is \"\"."
+                        "* The extension of \"/home/user1/file.tar.gz\" is \"gz\".",
+                        "* The extension of \"/home/user1/.file\" is null.",
+                        "* The extension of \"/usr/bin/sq\" is null.",
+                        "* The extension of \"/usr/bin/\" is null.",
+                        "* The extension of \"/\" is null."
                     ],
                     "return_type": "SqOsString",
                     "return_sequence_type": "Option",
@@ -252,7 +278,7 @@
                             "doc": "Whether to dereference symlinks",
                             "type": "PrimitiveBool",
                             "required": false,
-                            "default_value": false
+                            "default_value": true
                         },
                         {
                             "index": 2,

--- a/src/system/sqosstring.rs
+++ b/src/system/sqosstring.rs
@@ -7,6 +7,7 @@ use std::ffi::OsString;
 use anyhow::anyhow;
 
 use crate::primitive::Primitive;
+use crate::system::sqstring::SqString;
 use crate::system::SqOsStringTrait;
 
 pub struct SqOsString {
@@ -28,5 +29,13 @@ impl SqOsString {
 impl SqOsStringTrait for SqOsString {
     fn to_primitive(&self) -> anyhow::Result<Primitive> {
         Ok(Primitive::Str(self.to_str()?.to_owned()))
+    }
+
+    fn string(&self, replace_invalid: Option<bool>) -> anyhow::Result<SqString> {
+        if replace_invalid.unwrap_or(false) {
+            Ok(SqString::new(self.value.to_string_lossy().into_owned()))
+        } else {
+            Ok(SqString::new(self.to_str()?.to_owned()))
+        }
     }
 }

--- a/src/system/sqpath.rs
+++ b/src/system/sqpath.rs
@@ -35,8 +35,12 @@ impl SqPathTrait for SqPath {
         Ok(Primitive::Str(self.to_str()?.to_owned()))
     }
 
-    fn string(&self) -> anyhow::Result<SqString> {
-        Ok(SqString::new(self.to_str()?.to_owned()))
+    fn string(&self, replace_invalid: Option<bool>) -> anyhow::Result<SqString> {
+        if replace_invalid.unwrap_or(false) {
+            Ok(SqString::new(self.path.to_string_lossy().into_owned()))
+        } else {
+            Ok(SqString::new(self.to_str()?.to_owned()))
+        }
     }
 
     fn os_string(&self) -> anyhow::Result<SqOsString> {

--- a/tests/integration_test_util/mod.rs
+++ b/tests/integration_test_util/mod.rs
@@ -9,7 +9,96 @@ use sqr::error::{ErrorKind, Result};
 use sqr::parser::Parser;
 use sqr::{lexer, results, system};
 
-pub fn run_query(query: &str) -> Result<String> {
+// Rust doesn't seem to see that this struct is actually used.
+#[allow(dead_code)]
+pub struct TempFiles {
+    temp_dir: tempfile::TempDir,
+    paths: Vec<std::path::PathBuf>,
+}
+
+impl TempFiles {
+    // Rust doesn't seem to see that this function is actually used.
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        Self {
+            temp_dir: tempfile::TempDir::new().unwrap(),
+            paths: Vec::new(),
+        }
+    }
+
+    // Rust doesn't seem to see that this function is actually used.
+    #[allow(dead_code)]
+    pub fn temp_dir(&self) -> String {
+        self.temp_dir
+            .path()
+            .canonicalize()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_owned()
+    }
+
+    // Rust doesn't seem to see that this function is actually used.
+    #[allow(dead_code)]
+    pub fn abs_path(&self, rel_path: &str) -> std::path::PathBuf {
+        self.temp_dir.path().join(rel_path)
+    }
+
+    // Rust doesn't seem to see that this function is actually used.
+    #[allow(dead_code)]
+    pub fn abs_path_string(&self, rel_path: &str) -> String {
+        self.abs_path(rel_path).to_str().unwrap().to_owned()
+    }
+
+    // Rust doesn't seem to see that this function is actually used.
+    #[allow(dead_code)]
+    pub fn file(mut self, rel_path: &str) -> Self {
+        let pathbuf = self.abs_path(rel_path);
+        std::fs::write(&pathbuf, "").unwrap();
+        self.paths.push(pathbuf);
+        self
+    }
+
+    // Rust doesn't seem to see that this function is actually used.
+    #[allow(dead_code)]
+    pub fn dir(mut self, rel_path: &str) -> Self {
+        let pathbuf = self.abs_path(rel_path);
+        std::fs::create_dir(&pathbuf).unwrap();
+        self.paths.push(pathbuf);
+        self
+    }
+
+    // Rust doesn't seem to see that this function is actually used.
+    #[allow(dead_code)]
+    pub fn symlink(mut self, rel_target_path: &str, rel_path: &str) -> Self {
+        let target_path = self.abs_path(rel_target_path);
+        let path = self.abs_path(rel_path);
+        std::os::unix::fs::symlink(&target_path, &path).unwrap();
+        self.paths.push(path);
+        self
+    }
+
+    // Rust doesn't seem to see that this function is actually used.
+    #[allow(dead_code)]
+    pub fn chmod(self, rel_path: &str, mode: u32) -> Self {
+        use std::os::unix::fs::PermissionsExt;
+        let path = self.abs_path(rel_path);
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(mode);
+        std::fs::set_permissions(&path, perms).unwrap();
+        self
+    }
+}
+
+impl std::ops::Index<usize> for TempFiles {
+    type Output = str;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        self.paths[index].to_str().unwrap()
+    }
+}
+
+pub fn get_query(query: &str) -> Result<String> {
     let tokens = lexer::lex(query)?;
 
     let mut p = Parser::new(query, &tokens);
@@ -23,9 +112,30 @@ pub fn run_query(query: &str) -> Result<String> {
 
 // Rust doesn't seem to see that this function is actually used.
 #[allow(dead_code)]
+pub fn get_query_as<T>(query: &str) -> T
+where
+    T: for<'a> serde::de::Deserialize<'a>,
+{
+    serde_json::from_str::<T>(&get_query(query).unwrap()).unwrap()
+}
+
+// Rust doesn't seem to see that this function is actually used.
+#[allow(dead_code)]
+pub fn get_query_as_sorted_vec<T>(query: &str) -> Vec<T>
+where
+    Vec<T>: for<'a> serde::de::Deserialize<'a>,
+    T: Ord,
+{
+    let mut results = get_query_as::<Vec<T>>(query);
+    results.sort();
+    results
+}
+
+// Rust doesn't seem to see that this function is actually used.
+#[allow(dead_code)]
 pub fn test_query_ok(query: &str, expected: JsonValue) {
     assert_eq!(
-        serde_json::from_str::<serde_json::Value>(run_query(query).unwrap().as_str()).unwrap(),
+        serde_json::from_str::<JsonValue>(get_query(query).unwrap().as_str()).unwrap(),
         expected,
     );
 }
@@ -54,7 +164,7 @@ pub(crate) use test_simple_query_ok;
 // Rust doesn't seem to see that this function is actually used.
 #[allow(dead_code)]
 pub fn test_query_err(query: &str, kind: ErrorKind) {
-    assert_eq!(run_query(query).unwrap_err().kind(), kind);
+    assert_eq!(get_query(query).unwrap_err().kind(), kind);
 }
 
 // Rust doesn't seem to see that this macro is actually used.

--- a/tests/sqpath.rs
+++ b/tests/sqpath.rs
@@ -1,0 +1,443 @@
+// SPDX-FileCopyrightText: 2023 Jonathan Haigh <jonathanhaigh@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+use std::ffi::OsString;
+use std::fs;
+use std::os::unix::ffi::OsStringExt;
+use std::path::PathBuf;
+
+use rstest::rstest;
+use serde_json::json;
+use tempfile::TempDir;
+
+use integration_test_util::{
+    get_query, get_query_as, get_query_as_sorted_vec, test_query_err, test_query_ok,
+    test_simple_query_ok, TempFiles,
+};
+use sqr::error::ErrorKind;
+
+mod integration_test_util;
+
+test_simple_query_ok!(
+    sqpath_string,
+    all_unicode_planes,
+        "<path(\"\u{B123}\u{1B123}\u{2B123}\u{30123}\u{E0021}\u{F0001}\").<string",
+        json!("\u{B123}\u{1B123}\u{2B123}\u{30123}\u{E0021}\u{F0001}");
+);
+
+#[rstest]
+#[case::invalid_2octet_seq(vec![0xc3, 0x28])]
+#[case::invalid_seq_identifier(vec![0xa0, 0xa1])]
+#[case::invalid_2nd_of_3_octets(vec![0xe2, 0x28, 0xa1])]
+#[case::invalid_3rd_of_3_octets(vec![0xe2, 0x82, 0x28])]
+#[case::invalid_2nd_of_4_octets(vec![0xf0, 0x28, 0x8c, 0xbc])]
+#[case::invalid_3rd_of_4_octets(vec![0xf0, 0x90, 0x28, 0xbc])]
+#[case::invalid_4th_of_4_octets(vec![0xf0, 0x28, 0x8c, 0x28])]
+fn sqpath_string_invalid_utf8_err(#[case] bytes: Vec<u8>) {
+    let filename = PathBuf::from(OsString::from_vec(bytes));
+    let temp_dir = TempDir::new().unwrap();
+    fs::write(temp_dir.path().join(filename), "").unwrap();
+    let query = format!(
+        "path(\"{}\").children[0].string",
+        temp_dir.path().to_str().unwrap()
+    );
+    test_query_err(&query, ErrorKind::System);
+}
+
+#[rstest]
+#[case::invalid_2octet_seq(vec![0xc3, 0x28])]
+#[case::invalid_seq_identifier(vec![0xa0, 0xa1])]
+#[case::invalid_2nd_of_3_octets(vec![0xe2, 0x28, 0xa1])]
+#[case::invalid_3rd_of_3_octets(vec![0xe2, 0x82, 0x28])]
+#[case::invalid_2nd_of_4_octets(vec![0xf0, 0x28, 0x8c, 0xbc])]
+#[case::invalid_3rd_of_4_octets(vec![0xf0, 0x90, 0x28, 0xbc])]
+#[case::invalid_4th_of_4_octets(vec![0xf0, 0x28, 0x8c, 0x28])]
+fn sqpath_string_replace_invalid_utf8(#[case] bytes: Vec<u8>) {
+    let filename = PathBuf::from(OsString::from_vec(bytes));
+    let temp_dir = TempDir::new().unwrap();
+    fs::write(temp_dir.path().join(filename), "").unwrap();
+    let query = format!(
+        "path(\"{}\").children[0].string(replace_invalid=true)",
+        temp_dir.path().to_str().unwrap()
+    );
+    assert!(get_query(&query).is_ok());
+}
+
+#[rstest]
+#[case::invalid_2octet_seq(vec![0xc3, 0x28])]
+#[case::invalid_seq_identifier(vec![0xa0, 0xa1])]
+#[case::invalid_2nd_of_3_octets(vec![0xe2, 0x28, 0xa1])]
+#[case::invalid_3rd_of_3_octets(vec![0xe2, 0x82, 0x28])]
+#[case::invalid_2nd_of_4_octets(vec![0xf0, 0x28, 0x8c, 0xbc])]
+#[case::invalid_3rd_of_4_octets(vec![0xf0, 0x90, 0x28, 0xbc])]
+#[case::invalid_4th_of_4_octets(vec![0xf0, 0x28, 0x8c, 0x28])]
+fn sqpath_os_string_invalid_utf8(#[case] bytes: Vec<u8>) {
+    let filename = PathBuf::from(OsString::from_vec(bytes));
+    let temp_dir = TempDir::new().unwrap();
+    fs::write(temp_dir.path().join(filename), "").unwrap();
+    let query = format!(
+        "<path(\"{}\").<children[0].<os_string.<string(replace_invalid=true)",
+        temp_dir.path().to_str().unwrap()
+    );
+    assert!(get_query(&query).is_ok());
+}
+
+test_simple_query_ok!(
+    sqpath_parent,
+    tar, r#"<path("/home/user1/file.tar").<parent"#, json!("/home/user1");
+    tar_gz, r#"<path("home/user1/file.tar.gz").<parent"#, json!("home/user1");
+    with_hidden_filename, r#"<path("/home/user1/.file").<parent"#, json!("/home/user1");
+    usr_bin_sq, r#"<path("usr/bin/sq").<parent"#, json!("usr/bin");
+    with_slash_suffix, r#"<path("/usr/bin/").<parent"#, json!("/usr");
+    slash, r#"<path("/").<parent"#, json!(Option::<()>::None);
+);
+
+test_simple_query_ok!(
+    sqpath_filename,
+    tar, r#"<path("/home/user1/file.tar").<filename"#, json!("file.tar");
+    tar_gz, r#"<path("home/user1/file.tar.gz").<filename"#, json!("file.tar.gz");
+    hidden_filename, r#"<path("/home/user1/.file").<filename"#, json!(".file");
+    usr_bin_sq, r#"<path("usr/bin/sq").<filename"#, json!("sq");
+    with_slash_suffix, r#"<path("/usr/bin/").<filename"#, json!("bin");
+    slash, r#"<path("/").<filename"#, json!(Option::<()>::None);
+);
+
+test_simple_query_ok!(
+    sqpath_stem,
+    tar, r#"<path("/home/user1/file.tar").<stem"#, json!("file");
+    tar_gz, r#"<path("home/user1/file.tar.gz").<stem"#, json!("file.tar");
+    hidden_stem, r#"<path("/home/user1/.file").<stem"#, json!(".file");
+    usr_bin_sq, r#"<path("usr/bin/sq").<stem"#, json!("sq");
+    with_slash_suffix, r#"<path("/usr/bin/").<stem"#, json!("bin");
+    slash, r#"<path("/").<stem"#, json!(Option::<()>::None);
+);
+
+#[test]
+fn sqpath_exists_true() {
+    let temp_files = TempFiles::new().file("a_filename");
+    let query = format!("<path(\"{}\").<exists", temp_files[0].to_owned());
+    test_query_ok(&query, json!(true));
+}
+
+#[test]
+fn sqpath_exists_false() {
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("a_filename");
+    let query = format!("<path(\"{}\").<exists", file_path.to_str().unwrap());
+    test_query_ok(&query, json!(false));
+}
+
+test_simple_query_ok!(
+    sqpath_extension,
+    tar, r#"<path("/home/user1/file.tar").<extension"#, json!("tar");
+    tar_gz, r#"<path("home/user1/file.tar.gz").<extension"#, json!("gz");
+    hidden_extension, r#"<path("/home/user1/.file").<extension"#, json!(Option::<()>::None);
+    usr_bin_sq, r#"<path("usr/bin/sq").<extension"#, json!(Option::<()>::None);
+    with_slash_suffix, r#"<path("/usr/bin/").<extension"#, json!(Option::<()>::None);
+    slash, r#"<path("/").<extension"#, json!(Option::<()>::None);
+);
+
+#[test]
+fn sqpath_children_none() {
+    let temp_files = TempFiles::new();
+    let query = format!("<path(\"{}\").<children", temp_files.temp_dir());
+    test_query_ok(&query, json!([]));
+}
+
+#[test]
+fn sqpath_children_some() {
+    let temp_files = TempFiles::new().file("file1").file("file2");
+    let query = format!("<path(\"{}\").<children", temp_files.temp_dir());
+
+    assert_eq!(
+        get_query_as_sorted_vec::<String>(&query),
+        vec![temp_files[0].to_owned(), temp_files[1].to_owned()],
+    );
+}
+
+#[test]
+fn sqpath_children_hidden() {
+    let temp_files = TempFiles::new().file(".file1");
+    let query = format!("<path(\"{}\").<children", temp_files.temp_dir());
+    assert_eq!(
+        get_query_as_sorted_vec::<String>(&query),
+        vec![temp_files[0].to_owned()]
+    );
+}
+
+#[test]
+fn sqpath_children_dir() {
+    let temp_files = TempFiles::new().dir("dir1");
+    let query = format!("<path(\"{}\").<children", temp_files.temp_dir());
+
+    assert_eq!(
+        get_query_as_sorted_vec::<String>(&query),
+        vec![temp_files[0].to_owned()]
+    );
+}
+
+#[test]
+fn sqpath_children_default_recurse() {
+    let temp_files = TempFiles::new().dir("dir1").file("dir1/file1");
+    let query = format!("<path(\"{}\").<children", temp_files.temp_dir());
+
+    assert_eq!(
+        get_query_as_sorted_vec::<String>(&query),
+        vec![temp_files[0].to_owned()]
+    );
+}
+
+#[test]
+fn sqpath_children_recurse_false() {
+    let temp_files = TempFiles::new().dir("dir1").file("dir1/file1");
+    let query = format!(
+        "<path(\"{}\").<children(recurse=false)",
+        temp_files.temp_dir()
+    );
+
+    assert_eq!(
+        get_query_as_sorted_vec::<String>(&query),
+        vec![temp_files[0].to_owned()]
+    );
+}
+
+#[test]
+fn sqpath_children_recurse_true() {
+    let temp_files = TempFiles::new().dir("dir1").file("dir1/file1");
+    let query = format!(
+        "<path(\"{}\").<children(recurse=true)",
+        temp_files.temp_dir()
+    );
+
+    assert_eq!(
+        get_query_as_sorted_vec::<String>(&query),
+        vec![temp_files[0].to_owned(), temp_files[1].to_owned()],
+    );
+}
+
+#[test]
+fn sqpath_children_default_follow_symlinks() {
+    let temp_files = TempFiles::new()
+        .dir("dir1")
+        .file("dir1/file1")
+        .dir("dir2")
+        .symlink("dir1", "dir2/symlink1");
+    let query = format!("<path(\"{}\").<children(recurse=true)", &temp_files[2]);
+
+    assert_eq!(
+        get_query_as_sorted_vec::<String>(&query),
+        vec![
+            temp_files.abs_path_string("dir2/symlink1"),
+            temp_files.abs_path_string("dir2/symlink1/file1"),
+        ],
+    );
+}
+
+#[test]
+fn sqpath_children_follow_symlinks_true() {
+    let temp_files = TempFiles::new()
+        .dir("dir1")
+        .file("dir1/file1")
+        .dir("dir2")
+        .symlink("dir1", "dir2/symlink1");
+    let query = format!(
+        "<path(\"{}\").<children(recurse=true, follow_symlinks=true)",
+        &temp_files[2]
+    );
+
+    assert_eq!(
+        get_query_as_sorted_vec::<String>(&query),
+        vec![
+            temp_files.abs_path_string("dir2/symlink1"),
+            temp_files.abs_path_string("dir2/symlink1/file1"),
+        ],
+    );
+}
+
+#[test]
+fn sqpath_children_follow_symlinks_false() {
+    let temp_files = TempFiles::new()
+        .dir("dir1")
+        .file("dir1/file1")
+        .dir("dir2")
+        .symlink("dir1", "dir2/symlink1");
+    let query = format!(
+        "<path(\"{}\").<children(recurse=true, follow_symlinks=false)",
+        &temp_files[2]
+    );
+
+    assert_eq!(
+        get_query_as_sorted_vec::<String>(&query),
+        vec![temp_files.abs_path_string("dir2/symlink1")],
+    );
+}
+
+#[test]
+fn sqpath_children_skip_default_permission_denied() {
+    let temp_files = TempFiles::new()
+        .dir("dir1")
+        .file("dir1/file1")
+        .chmod("dir1", 0222);
+    let query = format!("<path(\"{}\").<children", &temp_files[0]);
+
+    test_query_err(&query, ErrorKind::System);
+
+    temp_files.chmod("dir1", 0777);
+}
+
+#[test]
+fn sqpath_children_skip_default_permission_true() {
+    let temp_files = TempFiles::new()
+        .dir("dir1")
+        .file("dir1/file1")
+        .chmod("dir1", 0222);
+    let query = format!(
+        "<path(\"{}\").<children(skip_permission_denied=true)",
+        &temp_files[0]
+    );
+
+    assert_eq!(
+        get_query_as_sorted_vec::<String>(&query),
+        Vec::<String>::new()
+    );
+
+    temp_files.chmod("dir1", 0777);
+}
+
+#[test]
+fn sqpath_children_skip_default_permission_false() {
+    let temp_files = TempFiles::new()
+        .dir("dir1")
+        .file("dir1/file1")
+        .chmod("dir1", 0222);
+    let query = format!(
+        "<path(\"{}\").<children(skip_permission_denied=false)",
+        &temp_files[0]
+    );
+
+    test_query_err(&query, ErrorKind::System);
+
+    temp_files.chmod("dir1", 0777);
+}
+
+// TODO: tests SqPath::children same_filesystem param?
+
+test_simple_query_ok!(
+    sqpath_parts,
+    tar, r#"<path("/home/user1/file.tar").<parts"#, json!(["/", "home", "user1", "file.tar"]);
+    tar_gz, r#"<path("home/user1/file.tar.gz").<parts"#, json!(["home", "user1", "file.tar.gz"]);
+    with_hidden_filename, r#"<path("/home/user1/.file").<parts"#, json!(["/", "home", "user1", ".file"]);
+    usr_bin_sq, r#"<path("usr/bin/sq").<parts"#, json!(["usr", "bin", "sq"]);
+    with_slash_suffix, r#"<path("/usr/bin/").<parts"#, json!(["/", "usr", "bin"]);
+    slash, r#"<path("/").<parts"#, json!(["/"]);
+);
+
+test_simple_query_ok!(
+    sqpath_absolute_already_absolute,
+    tar, r#"<path("/home/user1/file.tar").<absolute"#, json!("/home/user1/file.tar");
+    tar_gz, r#"<path("/home/user1/file.tar.gz").<absolute"#, json!("/home/user1/file.tar.gz");
+    with_hidden_filename, r#"<path("/home/user1/.file").<absolute"#, json!("/home/user1/.file");
+    usr_bin_sq, r#"<path("/usr/bin/sq").<absolute"#, json!("/usr/bin/sq");
+    with_slash_suffix, r#"<path("/usr/bin/").<absolute"#, json!("/usr/bin/");
+    slash, r#"<path("/").<absolute"#, json!("/");
+);
+
+#[rstest]
+#[case::normal("home/user1/file.tar")]
+#[case::dot_slash_prefix("./home/user1/file.tar.gz")]
+#[case::dot_dot_slash_prefix("../home/user1/.file")]
+#[case::just_dot(".")]
+#[case::just_dot_dot("..")]
+fn sqpath_absolute_from_relative(#[case] rel_path: &str) {
+    let curr_dir_str = std::env::current_dir()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_owned();
+    let query = format!("<path(\"{}\").<absolute", rel_path);
+    let got = get_query_as::<String>(&query);
+    let expected = format!("{}/{}", curr_dir_str, rel_path);
+    assert_eq!(got, expected);
+}
+
+#[rstest]
+#[case::normal("file1")]
+#[case::with_dot("./file1")]
+#[case::with_dot_dot("dir1/../file1")]
+fn sqpath_canonical_already_absolute(#[case] tail: &str) {
+    let temp_files = TempFiles::new().dir("dir1").file("file1");
+    let query = format!("<path(\"{}/{}\").<canonical", temp_files.temp_dir(), tail);
+    let got = get_query_as::<String>(&query);
+    let expected = format!("{}/{}", temp_files.temp_dir(), "file1");
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn sqpath_canonical_with_symlink() {
+    let temp_files = TempFiles::new()
+        .dir("dir1")
+        .file("dir1/file1")
+        .symlink("dir1", "dir2");
+
+    let query = format!("<path(\"{}/dir2/file1\").<canonical", temp_files.temp_dir());
+    let got = get_query_as::<String>(&query);
+    let expected = format!("{}/dir1/file1", temp_files.temp_dir());
+    assert_eq!(got, expected);
+}
+
+test_simple_query_ok!(
+    sqpath_is_absolute,
+    normal_abs, r#"<path("/home/user1/file.tar").<is_absolute"#, json!(true);
+    normal_rel, r#"<path("home/user1/file.tar").<is_absolute"#, json!(false);
+    with_dot_abs, r#"<path("/home/./user1/file.tar").<is_absolute"#, json!(true);
+    with_dot_rel, r#"<path("home/./user1/file.tar").<is_absolute"#, json!(false);
+    with_dot_dot_abs, r#"<path("/home/../user1/file.tar").<is_absolute"#, json!(true);
+    with_dot_dot_rel, r#"<path("home/../user1/file.tar").<is_absolute"#, json!(false);
+    slash, r#"<path("/").<is_absolute"#, json!(true);
+);
+
+#[test]
+fn sqpath_file_default_follow_symlinks() {
+    let temp_files = TempFiles::new().file("file1").symlink("file1", "file2");
+
+    let query1 = format!("<path(\"{}/file1\").<file.<type", temp_files.temp_dir());
+    assert_eq!(get_query_as::<String>(&query1), "file");
+
+    let query2 = format!("<path(\"{}/file2\").<file.<type", temp_files.temp_dir());
+    assert_eq!(get_query_as::<String>(&query2), "file");
+}
+
+#[test]
+fn sqpath_file_follow_symlinks_true() {
+    let temp_files = TempFiles::new().file("file1").symlink("file1", "file2");
+
+    let query1 = format!(
+        "<path(\"{}/file1\").<file(follow_symlinks=true).<type",
+        temp_files.temp_dir()
+    );
+    assert_eq!(get_query_as::<String>(&query1), "file");
+
+    let query2 = format!(
+        "<path(\"{}/file2\").<file(follow_symlinks=true).<type",
+        temp_files.temp_dir()
+    );
+    assert_eq!(get_query_as::<String>(&query2), "file");
+}
+
+#[test]
+fn sqpath_file_follow_symlinks_false() {
+    let temp_files = TempFiles::new().file("file1").symlink("file1", "file2");
+
+    let query1 = format!(
+        "<path(\"{}/file1\").<file(follow_symlinks=true).<type",
+        temp_files.temp_dir()
+    );
+    assert_eq!(get_query_as::<String>(&query1), "file");
+
+    let query2 = format!(
+        "<path(\"{}/file2\").<file(follow_symlinks=false).<type",
+        temp_files.temp_dir()
+    );
+    assert_eq!(get_query_as::<String>(&query2), "symlink");
+}

--- a/tests/sqroot.rs
+++ b/tests/sqroot.rs
@@ -7,7 +7,7 @@ use std::env::var as env_var;
 use serde_json::json;
 
 use integration_test_util::{
-    run_query, test_query_err, test_query_ok, test_simple_query_err, test_simple_query_ok,
+    get_query, test_query_err, test_query_ok, test_simple_query_err, test_simple_query_ok,
 };
 use sqr::error::ErrorKind;
 
@@ -89,7 +89,7 @@ fn sqroot_user_by_name() {
 
 #[test]
 fn sqroot_user_by_uid() {
-    let uid_json = run_query("<user.<uid").unwrap();
+    let uid_json = get_query("<user.<uid").unwrap();
     let query = format!("<user(uid={}).<username", uid_json);
     test_query_ok(&query, json!(env_var("USER").unwrap()));
 }
@@ -107,7 +107,7 @@ test_simple_query_err!(
 
 #[test]
 fn sqroot_user_both_uid_and_name_err() {
-    let uid_json = run_query("<user.<uid").unwrap();
+    let uid_json = get_query("<user.<uid").unwrap();
     let query = format!(
         "user(uid={}, username=\"{}\")",
         uid_json,
@@ -119,14 +119,14 @@ fn sqroot_user_both_uid_and_name_err() {
 #[test]
 fn sqroot_group_default() {
     use serde_json::{from_str, Value};
-    let group_name_json = run_query("<user.<group.<name").unwrap();
+    let group_name_json = get_query("<user.<group.<name").unwrap();
     test_query_ok("<group.<name", from_str::<Value>(&group_name_json).unwrap());
 }
 
 #[test]
 fn sqroot_group_by_name() {
     use serde_json::{from_str, Value};
-    let group_name_json = run_query("<user.<group.<name").unwrap();
+    let group_name_json = get_query("<user.<group.<name").unwrap();
     let query = format!("<group(name={}).<name", group_name_json);
     test_query_ok(&query, from_str::<Value>(&group_name_json).unwrap());
 }
@@ -134,15 +134,15 @@ fn sqroot_group_by_name() {
 #[test]
 fn sqroot_group_by_gid() {
     use serde_json::{from_str, Value};
-    let gid_json = run_query("<user.<group.<gid").unwrap();
+    let gid_json = get_query("<user.<group.<gid").unwrap();
     let query = format!("<group(gid={}).<gid", gid_json);
     test_query_ok(&query, from_str::<Value>(&gid_json).unwrap());
 }
 
 #[test]
 fn sqroot_group_by_both_gid_and_name_err() {
-    let gid_json = run_query("<user.<group.<gid").unwrap();
-    let name_json = run_query("<user.<group.<name").unwrap();
+    let gid_json = get_query("<user.<group.<gid").unwrap();
+    let name_json = get_query("<user.<group.<name").unwrap();
     let query = format!("<group(gid={}, group_name={})", gid_json, name_json);
     test_query_err(&query, ErrorKind::System);
 }


### PR DESCRIPTION
To ease a couple of the tests, also add SqOsString::string and give SqPath::string an option to replace invalid unicode byte sequences.