### PR TITLE
Add tests for SqDataSize and fix SqDataSize fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +524,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "object"
 version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -868,6 +886,7 @@ name = "sqr"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "approx",
  "clap",
  "erased-serde",
  "fancy-regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ thiserror = "1.0.38"
 walkdir = "2.3"
 
 [dev-dependencies]
+approx = "0.5"
 pretty_assertions = "1.3.0"
 rstest = "0.17"
 slyce = "0.3.1"

--- a/src/system/schema.json
+++ b/src/system/schema.json
@@ -676,6 +676,22 @@
                     ]
                 },
                 {
+                    "name": "data_size",
+                    "doc": "Get an SqDataSize system object",
+                    "return_type": "SqDataSize",
+                    "return_sequence_type": "Single",
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "value",
+                            "doc": "the value, in bytes, of the data size to get",
+                            "type": "PrimitiveInt",
+                            "required": false,
+                            "default_value": 0
+                        }
+                    ]
+                },
+                {
                     "name": "float",
                     "doc": "Get an SqFloat system object",
                     "return_type": "SqFloat",

--- a/src/system/sqdatasize.rs
+++ b/src/system/sqdatasize.rs
@@ -10,13 +10,13 @@ use crate::system::{sqfloat::SqFloat, sqint::SqInt, SqDataSizeTrait};
 const KIB: f64 = 1024f64;
 const KB: f64 = 1000f64;
 const MIB: f64 = 1024f64 * KIB;
-const MB: f64 = 1000f64 * KIB;
+const MB: f64 = 1000f64 * KB;
 const GIB: f64 = 1024f64 * MIB;
-const GB: f64 = 1000f64 * MIB;
+const GB: f64 = 1000f64 * MB;
 const TIB: f64 = 1024f64 * GIB;
-const TB: f64 = 1000f64 * GIB;
+const TB: f64 = 1000f64 * GB;
 const PIB: f64 = 1024f64 * TIB;
-const PB: f64 = 1000f64 * TIB;
+const PB: f64 = 1000f64 * TB;
 
 pub struct SqDataSize {
     value: u64,

--- a/src/system/sqroot.rs
+++ b/src/system/sqroot.rs
@@ -11,8 +11,8 @@ use anyhow::{anyhow, ensure};
 use crate::primitive::Primitive;
 use crate::sqvalue::SqValueSequence;
 use crate::system::{
-    sqbool::SqBool, sqfloat::SqFloat, sqgroup::SqGroup, sqint::SqInt, sqpath::SqPath,
-    sqstring::SqString, squser::SqUser, SqRootTrait,
+    sqbool::SqBool, sqdatasize::SqDataSize, sqfloat::SqFloat, sqgroup::SqGroup, sqint::SqInt,
+    sqpath::SqPath, sqstring::SqString, squser::SqUser, SqRootTrait,
 };
 
 pub struct SqRoot {}
@@ -87,6 +87,14 @@ impl SqRootTrait for SqRoot {
 
     fn float(&self, value: Option<f64>) -> anyhow::Result<SqFloat> {
         Ok(SqFloat::new(value.unwrap_or(0f64)))
+    }
+
+    fn data_size(&self, value: Option<i64>) -> anyhow::Result<SqDataSize> {
+        let value = value.unwrap_or(0);
+        match u64::try_from(value) {
+            Ok(v) => Ok(SqDataSize::new(v)),
+            Err(_) => Err(anyhow!("Data size value must be non-negative")),
+        }
     }
 
     fn user(&self, opt_username: Option<&str>, opt_uid: Option<i64>) -> anyhow::Result<SqUser> {

--- a/tests/integration_test_util/mod.rs
+++ b/tests/integration_test_util/mod.rs
@@ -161,6 +161,42 @@ macro_rules! test_simple_query_ok {
 #[allow(unused_imports)]
 pub(crate) use test_simple_query_ok;
 
+// Rust doesn't seem to see that this macro is actually used.
+#[allow(unused_macros)]
+macro_rules! test_simple_query_approx_f64_ulp {
+    ($name:ident, $($case_name:ident, $query:expr, $expected:expr, $max_ulps:expr;)*) => {
+        mod $name {
+            use rstest::rstest;
+            #[rstest]
+            $(#[case::$case_name($query, $expected, $max_ulps)])*
+            fn test_query_approx_f64_ulp(#[case] query: &str, #[case] expected: f64, #[case] max_ulps: u32) {
+                let result = $crate::integration_test_util::get_query_as::<f64>(query);
+                approx::assert_ulps_eq!(result, expected, max_ulps=max_ulps);
+            }
+        }
+    }
+}
+#[allow(unused_imports)]
+pub(crate) use test_simple_query_approx_f64_ulp;
+
+// Rust doesn't seem to see that this macro is actually used.
+#[allow(unused_macros)]
+macro_rules! test_simple_query_approx_f64_abs_diff {
+    ($name:ident, $($case_name:ident, $query:expr, $expected:expr, $epsilon:expr;)*) => {
+        mod $name {
+            use rstest::rstest;
+            #[rstest]
+            $(#[case::$case_name($query, $expected, $epsilon)])*
+            fn test_query_approx_f64_ulp(#[case] query: &str, #[case] expected: f64, #[case] epsilon: f64) {
+                let result = $crate::integration_test_util::get_query_as::<f64>(query);
+                approx::assert_abs_diff_eq!(result, expected, epsilon=epsilon);
+            }
+        }
+    }
+}
+#[allow(unused_imports)]
+pub(crate) use test_simple_query_approx_f64_abs_diff;
+
 // Rust doesn't seem to see that this function is actually used.
 #[allow(dead_code)]
 pub fn test_query_err(query: &str, kind: ErrorKind) {

--- a/tests/sqdatasize.rs
+++ b/tests/sqdatasize.rs
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: 2023 Jonathan Haigh <jonathanhaigh@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+use integration_test_util::{
+    test_simple_query_approx_f64_abs_diff, test_simple_query_approx_f64_ulp, test_simple_query_ok,
+};
+
+mod integration_test_util;
+
+test_simple_query_ok!(
+    sqdatasize_b,
+    zero, "<data_size(0).<B", json!(0);
+    one, "<data_size(0).<B", json!(0);
+    i64_max, "<data_size(9223372036854775807)", json!(9_223_372_036_854_775_807i64);
+    // TODO: currently the only way to create an SqDataSize with a size bigger than i64::MAX bytes
+    // is to read the size of a file that has such a size. Perhaps we could create a sparse file
+    // like that or have another way to create such an SqDataSize.
+);
+
+test_simple_query_approx_f64_abs_diff!(
+    sqdatasize_zeroes,
+    kib, "<data_size(0).<KiB", 0f64, f64::EPSILON;
+    mib, "<data_size(0).<MiB", 0f64, f64::EPSILON;
+    gib, "<data_size(0).<GiB", 0f64, f64::EPSILON;
+    tib, "<data_size(0).<TiB", 0f64, f64::EPSILON;
+    pib, "<data_size(0).<PiB", 0f64, f64::EPSILON;
+    kb, "<data_size(0).<kB", 0f64, f64::EPSILON;
+    mb, "<data_size(0).<MB", 0f64, f64::EPSILON;
+    gb, "<data_size(0).<GB", 0f64, f64::EPSILON;
+    tb, "<data_size(0).<TB", 0f64, f64::EPSILON;
+    pb, "<data_size(0).<PB", 0f64, f64::EPSILON;
+);
+
+test_simple_query_approx_f64_ulp!(
+    sqdatasize_kib,
+    one, "<data_size(1).<KiB", 0.0009765625f64, 4;
+    ten, "<data_size(10).<KiB", 0.009765625f64, 4;
+    hundred, "<data_size(100).<KiB", 0.09765625f64, 4;
+    k, "<data_size(1000).<KiB", 0.9765625f64, 4;
+    m, "<data_size(1000000).<KiB", 976.5625f64, 4;
+    g, "<data_size(1000000000).<KiB", 976562.5f64, 4;
+    t, "<data_size(1000000000000).<KiB", 976562500f64, 4;
+    p, "<data_size(1000000000000000).<KiB", 976562500000f64, 4;
+    ki, "<data_size(1024).<KiB", 1f64, 4;
+    mi, "<data_size(1048576).<KiB", 1024f64, 4;
+    gi, "<data_size(1073741824).<KiB", 1048576f64, 4;
+    ti, "<data_size(1099511627776).<KiB", 1073741824f64, 4;
+    pi, "<data_size(1125899906842624).<KiB", 1099511627776f64, 4;
+);
+
+test_simple_query_approx_f64_ulp!(
+    sqdatasize_kb,
+    one, "<data_size(1).<kB", 1e-3f64, 4;
+    ten, "<data_size(10).<kB", 1e-2f64, 4;
+    hundred, "<data_size(100).<kB", 1e-1f64, 4;
+    k, "<data_size(1000).<kB", 1e0f64, 4;
+    m, "<data_size(1000000).<kB", 1e3f64, 4;
+    g, "<data_size(1000000000).<kB", 1e6f64, 4;
+    t, "<data_size(1000000000000).<kB", 1e9f64, 4;
+    p, "<data_size(1000000000000000).<kB", 1e12f64, 4;
+    ki, "<data_size(1024).<kB", 1.024f64, 4;
+    mi, "<data_size(1048576).<kB", 1048.576f64, 4;
+    gi, "<data_size(1073741824).<kB", 1073741.824f64, 4;
+    ti, "<data_size(1099511627776).<kB", 1099511627.776f64, 4;
+    pi, "<data_size(1125899906842624).<kB", 1125899906842.624f64, 4;
+);
+
+test_simple_query_approx_f64_ulp!(
+    sqdatasize_mib,
+    one, "<data_size(1).<MiB", 9.5367431640625e-7f64, 4;
+    ten, "<data_size(10).<MiB", 9.5367431640625e-6f64, 4;
+    hundred, "<data_size(100).<MiB", 9.5367431640625e-5f64, 4;
+    k, "<data_size(1000).<MiB", 9.5367431640625e-4f64, 4;
+    m, "<data_size(1000000).<MiB", 9.5367431640625e-1f64, 4;
+    g, "<data_size(1000000000).<MiB", 9.5367431640625e2f64, 4;
+    t, "<data_size(1000000000000).<MiB", 9.5367431640625e5f64, 4;
+    p, "<data_size(1000000000000000).<MiB", 9.5367431640625e8f64, 4;
+    ki, "<data_size(1024).<MiB", 0.0009765625f64, 4;
+    mi, "<data_size(1048576).<MiB", 1f64, 4;
+    gi, "<data_size(1073741824).<MiB", 1024f64, 4;
+    ti, "<data_size(1099511627776).<MiB", 1048576f64, 4;
+    pi, "<data_size(1125899906842624).<MiB", 1073741824f64, 4;
+);
+
+test_simple_query_approx_f64_ulp!(
+    sqdatasize_mb,
+    one, "<data_size(1).<MB", 1e-6f64, 4;
+    ten, "<data_size(10).<MB", 1e-5f64, 4;
+    hundred, "<data_size(100).<MB", 1e-4f64, 4;
+    k, "<data_size(1000).<MB", 1e-3f64, 4;
+    m, "<data_size(1000000).<MB", 1e0f64, 4;
+    g, "<data_size(1000000000).<MB", 1e3f64, 4;
+    t, "<data_size(1000000000000).<MB", 1e6f64, 4;
+    p, "<data_size(1000000000000000).<MB", 1e9f64, 4;
+    ki, "<data_size(1024).<MB", 0.001024f64, 4;
+    mi, "<data_size(1048576).<MB", 1.048576f64, 4;
+    gi, "<data_size(1073741824).<MB", 1073.741824f64, 4;
+    ti, "<data_size(1099511627776).<MB", 1099511.627776f64, 4;
+    pi, "<data_size(1125899906842624).<MB", 1125899906.842624f64, 4;
+);
+
+test_simple_query_approx_f64_ulp!(
+    sqdatasize_gib,
+    one, "<data_size(1).<GiB", 9.31322574615478515625e-10f64, 4;
+    ten, "<data_size(10).<GiB", 9.31322574615478515625e-9f64, 4;
+    hundred, "<data_size(100).<GiB", 9.31322574615478515625e-8f64, 4;
+    k, "<data_size(1000).<GiB", 9.31322574615478515625e-7f64, 4;
+    m, "<data_size(1000000).<GiB", 9.31322574615478515625e-4f64, 4;
+    g, "<data_size(1000000000).<GiB", 9.31322574615478515625e-1f64, 4;
+    t, "<data_size(1000000000000).<GiB", 9.31322574615478515625e2f64, 4;
+    p, "<data_size(1000000000000000).<GiB", 9.31322574615478515625e5f64, 4;
+    ki, "<data_size(1024).<GiB", 9.5367431640625e-7f64, 4;
+    mi, "<data_size(1048576).<GiB", 0.0009765625f64, 4;
+    gi, "<data_size(1073741824).<GiB", 1f64, 4;
+    ti, "<data_size(1099511627776).<GiB", 1024f64, 4;
+    pi, "<data_size(1125899906842624).<GiB", 1048576f64, 4;
+);
+
+test_simple_query_approx_f64_ulp!(
+    sqdatasize_gb,
+    one, "<data_size(1).<GB", 1e-9f64, 4;
+    ten, "<data_size(10).<GB", 1e-8f64, 4;
+    hundred, "<data_size(100).<GB", 1e-7f64, 4;
+    k, "<data_size(1000).<GB", 1e-6f64, 4;
+    m, "<data_size(1000000).<GB", 1e-3f64, 4;
+    g, "<data_size(1000000000).<GB", 1e0f64, 4;
+    t, "<data_size(1000000000000).<GB", 1e3f64, 4;
+    p, "<data_size(1000000000000000).<GB", 1e6f64, 4;
+    ki, "<data_size(1024).<GB", 0.000001024f64, 4;
+    mi, "<data_size(1048576).<GB", 0.001048576f64, 4;
+    gi, "<data_size(1073741824).<GB", 1.073741824f64, 4;
+    ti, "<data_size(1099511627776).<GB", 1099.511627776f64, 4;
+    pi, "<data_size(1125899906842624).<GB", 1125899.906842624f64, 4;
+);
+
+test_simple_query_approx_f64_ulp!(
+    sqdatasize_tib,
+    one, "<data_size(1).<TiB", 9.094947017729282379150390625e-13f64, 4;
+    ten, "<data_size(10).<TiB", 9.094947017729282379150390625e-12f64, 4;
+    hundred, "<data_size(100).<TiB", 9.094947017729282379150390625e-11f64, 4;
+    k, "<data_size(1000).<TiB", 9.094947017729282379150390625e-10f64, 4;
+    m, "<data_size(1000000).<TiB", 9.094947017729282379150390625e-7f64, 4;
+    g, "<data_size(1000000000).<TiB", 9.094947017729282379150390625e-4f64, 4;
+    t, "<data_size(1000000000000).<TiB", 9.094947017729282379150390625e-1f64, 4;
+    p, "<data_size(1000000000000000).<TiB", 9.094947017729282379150390625e2f64, 4;
+    ki, "<data_size(1024).<TiB", 9.31322574615478515625E-10, 4;
+    mi, "<data_size(1048576).<TiB", 9.5367431640625e-7f64, 4;
+    gi, "<data_size(1073741824).<TiB", 0.0009765625f64, 4;
+    ti, "<data_size(1099511627776).<TiB", 1f64, 4;
+    pi, "<data_size(1125899906842624).<TiB", 1024f64, 4;
+);
+
+test_simple_query_approx_f64_ulp!(
+    sqdatasize_tb,
+    one, "<data_size(1).<TB", 1e-12f64, 4;
+    ten, "<data_size(10).<TB", 1e-11f64, 4;
+    hundred, "<data_size(100).<TB", 1e-10f64, 4;
+    k, "<data_size(1000).<TB", 1e-9f64, 4;
+    m, "<data_size(1000000).<TB", 1e-6f64, 4;
+    g, "<data_size(1000000000).<TB", 1e-3f64, 4;
+    t, "<data_size(1000000000000).<TB", 1e0f64, 4;
+    p, "<data_size(1000000000000000).<TB", 1e3f64, 4;
+    ki, "<data_size(1024).<TB", 0.000000001024f64, 4;
+    mi, "<data_size(1048576).<TB", 0.000001048576f64, 4;
+    gi, "<data_size(1073741824).<TB", 0.001073741824f64, 4;
+    ti, "<data_size(1099511627776).<TB", 1.099511627776f64, 4;
+    pi, "<data_size(1125899906842624).<TB", 1125.899906842624f64, 4;
+);
+
+test_simple_query_approx_f64_ulp!(
+    sqdatasize_pib,
+    one, "<data_size(1).<PiB", 8.8817841970012523233890533447265625e-16f64, 4;
+    ten, "<data_size(10).<PiB", 8.8817841970012523233890533447265625e-15f64, 4;
+    hundred, "<data_size(100).<PiB", 8.8817841970012523233890533447265625e-14f64, 4;
+    k, "<data_size(1000).<PiB", 8.8817841970012523233890533447265625e-13f64, 4;
+    m, "<data_size(1000000).<PiB", 8.8817841970012523233890533447265625e-10f64, 4;
+    g, "<data_size(1000000000).<PiB", 8.8817841970012523233890533447265625e-7f64, 4;
+    t, "<data_size(1000000000000).<PiB", 8.8817841970012523233890533447265625e-4f64, 4;
+    p, "<data_size(1000000000000000).<PiB", 8.8817841970012523233890533447265625e-1f64, 4;
+    ki, "<data_size(1024).<PiB", 9.094947017729282379150390625e-13f64, 4;
+    mi, "<data_size(1048576).<PiB", 9.31322574615478515625E-10, 4;
+    gi, "<data_size(1073741824).<PiB", 9.5367431640625e-7f64, 4;
+    ti, "<data_size(1099511627776).<PiB", 0.0009765625f64, 4;
+    pi, "<data_size(1125899906842624).<PiB", 1f64, 4;
+);
+
+test_simple_query_approx_f64_ulp!(
+    sqdatasize_pb,
+    one, "<data_size(1).<PB", 1e-15f64, 4;
+    ten, "<data_size(10).<PB", 1e-14f64, 4;
+    hundred, "<data_size(100).<PB", 1e-13f64, 4;
+    k, "<data_size(1000).<PB", 1e-12f64, 4;
+    m, "<data_size(1000000).<PB", 1e-9f64, 4;
+    g, "<data_size(1000000000).<PB", 1e-6f64, 4;
+    t, "<data_size(1000000000000).<PB", 1e-3f64, 4;
+    p, "<data_size(1000000000000000).<PB", 1e0f64, 4;
+    ki, "<data_size(1024).<PB", 0.000000000001024f64, 4;
+    mi, "<data_size(1048576).<PB", 0.000000001048576f64, 4;
+    gi, "<data_size(1073741824).<PB", 0.000001073741824f64, 4;
+    ti, "<data_size(1099511627776).<PB", 0.001099511627776f64, 4;
+    pi, "<data_size(1125899906842624).<PB", 1.125899906842624f64, 4;
+);

--- a/tests/sqroot.rs
+++ b/tests/sqroot.rs
@@ -38,6 +38,19 @@ test_simple_query_ok!(
 );
 
 test_simple_query_ok!(
+    sqroot_data_size,
+    default_value, "<data_size", json!(0i64);
+    one, "<data_size(1)", json!(1i64);
+    i64_max, "<data_size(9223372036854775807)", json!(9_223_372_036_854_775_807i64);
+);
+
+test_simple_query_err!(
+    sqroot_data_size_err,
+    minus_one, "<data_size(-1)", System;
+    i64_min, "<data_size(-9223372036854775808)", System;
+);
+
+test_simple_query_ok!(
     sqroot_string,
     default_value, "<string", json!("");
     all_unicode_planes,


### PR DESCRIPTION
Testing showed that the constants used for the SI data size units were wrong, so fix those.

Also, add the SqRoot::data_size field to make testing easier.

For: #27 (Add integration tests)