### PR TITLE
Add more primitive integer types

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -302,7 +302,7 @@ impl<'es> SchemaGenerator<'es> {
             (_, JsonValue::Null) => Ok(quote! {DefaultValue::Null}),
             ("PrimitiveBool", JsonValue::Bool(b)) => Ok(quote! {DefaultValue::Bool(#b)}),
             ("PrimitiveInt", JsonValue::Number(n)) if n.is_i64() => {
-                let i = n.as_i64().unwrap();
+                let i = i128::from(n.as_i64().unwrap());
                 Ok(quote! {DefaultValue::Int(#i)})
             }
             // Note that serde_json::value::Number::is_f64() returns true only if the number is not
@@ -390,7 +390,7 @@ impl<'es> SqTypeTraitGenerator<'es> {
         let param_name = format_ident!("p_{}", &param_ext.name);
         let mut param_type = match &param_ext.ty[..] {
             "PrimitiveBool" => quote! {bool},
-            "PrimitiveInt" => quote! {i64},
+            "PrimitiveInt" => quote! {i128},
             "PrimitiveFloat" => quote! {f64},
             "PrimitiveString" => quote! {&str},
             // The internal schema generation should already have errored if the type is invalid so
@@ -563,7 +563,7 @@ impl<'es> SqValueImplementor<'es> {
                     // Unless it's a &str we'll want to clone it before dispatching it to the
                     // field-specific getter.
                     "PrimitiveBool" => (quote! {bool}, quote! {.copied()}),
-                    "PrimitiveInt" => (quote! {i64}, quote! {.copied()}),
+                    "PrimitiveInt" => (quote! {i128}, quote! {.copied()}),
                     "PrimitiveFloat" => (quote! {f64}, quote! {.copied()}),
                     "PrimitiveString" => (quote! {str}, quote! {}),
                     t => panic!("Unrecognized primitive type {}", t),

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -99,7 +99,7 @@ pub enum Filter {
 #[derive(Clone, Debug, PartialEq)]
 pub struct IntLiteral {
     pub span: SourceSpan,
-    pub value: i64,
+    pub value: i128,
 }
 
 /// AST node representing a `slice` grammar item in a `filter_pack`: a Python style slice.

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,7 @@ pub enum ErrorKind {
     FilterIndexOutOfBounds,
     SliceStepZero,
     ConvertInteger,
+    ConvertIntegerArg,
     NonSingleFieldInComparison,
     ComparisonTypeMismatch,
 }
@@ -215,6 +216,21 @@ pub enum Error {
         value: String,
     },
 
+    /// An error converting to and argument's integer type.
+    #[error(
+        "error converting integer {value} to {type_name}::{field_name} {param_name} argument type {param_type}"
+    )]
+    ConvertIntegerArg {
+        #[label("failed conversion")]
+        span: SourceSpan,
+
+        type_name: String,
+        field_name: String,
+        param_name: String,
+        param_type: String,
+        value: i128,
+    },
+
     /// Field that doesn't return Single sequence type in a comparison filter.
     #[error(
         "non-Single return sequence type {sequence_type} for {type_name}::{field_name} cannot be used in comparison filters"
@@ -265,6 +281,7 @@ impl Error {
             Error::FilterIndexOutOfBounds { .. } => ErrorKind::FilterIndexOutOfBounds,
             Error::SliceStepZero { .. } => ErrorKind::SliceStepZero,
             Error::ConvertInteger { .. } => ErrorKind::ConvertInteger,
+            Error::ConvertIntegerArg { .. } => ErrorKind::ConvertIntegerArg,
             Error::NonSingleFieldInComparison { .. } => ErrorKind::NonSingleFieldInComparison,
             Error::ComparisonTypeMismatch { .. } => ErrorKind::ComparisonTypeMismatch,
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -186,7 +186,7 @@ pub enum Error {
 
         type_name: String,
         field_name: String,
-        index: i64,
+        index: i128,
         len: usize,
     },
 

--- a/src/filter/index.rs
+++ b/src/filter/index.rs
@@ -38,7 +38,7 @@ impl<'a> IndexFilter<'a> {
         }
     }
 
-    fn raw_index(&self) -> i64 {
+    fn raw_index(&self) -> i128 {
         self.int_literal.value
     }
 
@@ -236,9 +236,9 @@ mod tests {
 
         #[case] seq_len: usize,
 
-        #[case] index: i64,
+        #[case] index: i128,
 
-        #[case] expected: Option<i64>,
+        #[case] expected: Option<i128>,
     ) {
         let field_call_ast = fake_field_call_ast();
         let call_info = FieldCallInfo::new(&field_call_ast, schema::root_field());
@@ -253,7 +253,7 @@ mod tests {
                     .unwrap()
                     .get_primitive(&call_info)
                     .unwrap(),
-                Primitive::Int(v)
+                Primitive::from(v)
             ),
             None => assert!(filter.filter(seq).is_err()),
         }

--- a/src/filter/slice.rs
+++ b/src/filter/slice.rs
@@ -980,6 +980,7 @@ mod tests {
     use super::*;
     use crate::schema;
     use crate::test_util::{fake_field_call_ast, fake_int_literal, gen_sqbvalue_seq, SequenceType};
+    use crate::util::TryAs;
 
     fn fake_slice(start: Option<i128>, stop: Option<i128>, step: Option<i128>) -> ast::Slice {
         ast::Slice {
@@ -1005,8 +1006,14 @@ mod tests {
         let got = filter
             .filter(seq)
             .unwrap()
-            .map(|f| i128::try_from(f.unwrap().get_primitive(&call_info).unwrap()).unwrap())
-            .collect::<Vec<_>>();
+            .map(|f| {
+                f.unwrap()
+                    .get_primitive(&call_info)
+                    .unwrap()
+                    .try_as()
+                    .unwrap()
+            })
+            .collect::<Vec<i128>>();
 
         let expected = slyce::Slice {
             start: start.map(|i| isize::try_from(i).unwrap()).into(),

--- a/src/filter/slice.rs
+++ b/src/filter/slice.rs
@@ -981,7 +981,7 @@ mod tests {
     use crate::schema;
     use crate::test_util::{fake_field_call_ast, fake_int_literal, gen_sqbvalue_seq, SequenceType};
 
-    fn fake_slice(start: Option<i64>, stop: Option<i64>, step: Option<i64>) -> ast::Slice {
+    fn fake_slice(start: Option<i128>, stop: Option<i128>, step: Option<i128>) -> ast::Slice {
         ast::Slice {
             span: (0, 0).into(),
             opt_start: start.map(fake_int_literal),
@@ -991,9 +991,9 @@ mod tests {
     }
 
     fn test_slice_case(
-        start: Option<i64>,
-        stop: Option<i64>,
-        step: Option<i64>,
+        start: Option<i128>,
+        stop: Option<i128>,
+        step: Option<i128>,
         seq_type: SequenceType,
         seq_len: usize,
     ) -> std::result::Result<(), String> {
@@ -1005,7 +1005,7 @@ mod tests {
         let got = filter
             .filter(seq)
             .unwrap()
-            .map(|f| i64::try_from(f.unwrap().get_primitive(&call_info).unwrap()).unwrap())
+            .map(|f| i128::try_from(f.unwrap().get_primitive(&call_info).unwrap()).unwrap())
             .collect::<Vec<_>>();
 
         let expected = slyce::Slice {
@@ -1014,7 +1014,7 @@ mod tests {
             step: step.map(|i| isize::try_from(i).unwrap()).into(),
         }
         .apply(
-            (0..i64::try_from(seq_len).unwrap())
+            (0..i128::try_from(seq_len).unwrap())
                 .collect::<Vec<_>>()
                 .as_slice(),
         )
@@ -1043,9 +1043,9 @@ mod tests {
         steps.push(None);
 
         // element types in the input iterators to itertools::multi_cartesian_product must be the
-        // same, so convert the SequenceTypes to i64s and wrap in Some.
+        // same, so convert the SequenceTypes to i128s and wrap in Some.
         let seq_types = SequenceType::iter()
-            .map(|v| Some(v as i64))
+            .map(|v| Some(v as i128))
             .collect::<Vec<_>>();
 
         // element types in the input iterators to itertools::multi_cartesian_product must be the

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12,7 +12,7 @@ use crate::ast;
 use crate::error::{Error, OptResult, Result};
 use crate::fieldcall::FieldAccessKind;
 use crate::lexer::{Token, TokenKind};
-use crate::primitive::Primitive::{Bool, Float, Int, Str};
+use crate::primitive::Primitive::{Bool, Str, F64, I128};
 use crate::util::return_none_or_err;
 
 /// An SQ query parser.
@@ -706,13 +706,13 @@ impl<'q> Parser<'q> {
         if let Some((span, int_val)) = self.parse_int()? {
             return Ok(Some(ast::Literal {
                 span,
-                value: Int(int_val),
+                value: I128(int_val),
             }));
         }
         if let Some((span, float_val)) = self.parse_float()? {
             return Ok(Some(ast::Literal {
                 span,
-                value: Float(float_val),
+                value: F64(float_val),
             }));
         }
         if let Some((span, string_val)) = self.parse_str()? {
@@ -1030,11 +1030,11 @@ mod tests {
                     pos_args: vec![
                         ast::Literal {
                             span: (3, 3).into(),
-                            value: Float(1.2),
+                            value: F64(1.2),
                         },
                         ast::Literal {
                             span: (8, 1).into(),
-                            value: Int(5),
+                            value: I128(5),
                         }
                     ],
                     named_args: ast::NamedArgs::new(),
@@ -1076,7 +1076,7 @@ mod tests {
                             },
                             literal: ast::Literal {
                                 span: (15, 4).into(),
-                                value: Float(-5.8),
+                                value: F64(-5.8),
                             },
                         },
                     ],
@@ -1109,7 +1109,7 @@ mod tests {
                         },
                         literal: ast::Literal {
                             span: (15, 2).into(),
-                            value: Int(42),
+                            value: I128(42),
                         },
                     }],
                 }),
@@ -1338,7 +1338,7 @@ mod tests {
             "1234",
             ast::Literal {
                 span: (0, 4).into(),
-                value: Int(1234)
+                value: I128(1234)
             }
         ),
         (
@@ -1347,7 +1347,7 @@ mod tests {
             "1.234",
             ast::Literal {
                 span: (0, 5).into(),
-                value: Float(1.234)
+                value: F64(1.234)
             }
         ),
         (
@@ -1385,7 +1385,7 @@ mod tests {
                 },
                 literal: ast::Literal {
                     span: (2, 2).into(),
-                    value: Int(99)
+                    value: I128(99)
                 },
             }
         ),
@@ -1401,7 +1401,7 @@ mod tests {
                 },
                 literal: ast::Literal {
                     span: (2, 3).into(),
-                    value: Float(9.9),
+                    value: F64(9.9),
                 },
             }
         ),
@@ -1683,7 +1683,7 @@ mod tests {
                 },
                 literal: ast::Literal {
                     span: (9, 2).into(),
-                    value: Int(-7)
+                    value: I128(-7)
                 },
             }
         ),
@@ -1700,7 +1700,7 @@ mod tests {
                 },
                 literal: ast::Literal {
                     span: (3, 2).into(),
-                    value: Int(-7)
+                    value: I128(-7)
                 },
             }
         ),
@@ -1717,7 +1717,7 @@ mod tests {
                 },
                 literal: ast::Literal {
                     span: (13, 5).into(),
-                    value: Float(1.7e9)
+                    value: F64(1.7e9)
                 },
             }
         ),
@@ -1734,7 +1734,7 @@ mod tests {
                 },
                 literal: ast::Literal {
                     span: (2, 5).into(),
-                    value: Float(1.7e9)
+                    value: F64(1.7e9)
                 },
             }
         ),
@@ -1785,7 +1785,7 @@ mod tests {
                 },
                 literal: ast::Literal {
                     span: (6, 1).into(),
-                    value: Int(9)
+                    value: I128(9)
                 },
             }
         ),
@@ -1802,7 +1802,7 @@ mod tests {
                 },
                 literal: ast::Literal {
                     span: (2, 1).into(),
-                    value: Int(9)
+                    value: I128(9)
                 },
             }
         ),
@@ -1850,7 +1850,7 @@ mod tests {
                 },
                 literal: ast::Literal {
                     span: (12, 1).into(),
-                    value: Int(9)
+                    value: I128(9)
                 },
             }
         ),
@@ -2133,7 +2133,7 @@ mod tests {
                     },
                     literal: ast::Literal {
                         span: (6, 2).into(),
-                        value: Int(10)
+                        value: I128(10)
                     },
                 }))
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -746,9 +746,9 @@ impl<'q> Parser<'q> {
     }
 
     // Int
-    fn parse_int(&mut self) -> OptResult<(SourceSpan, i64)> {
+    fn parse_int(&mut self) -> OptResult<(SourceSpan, i128)> {
         let tok = return_none_or_err!(self.accept_token(TokenKind::Int));
-        match tok.text(self.query).parse::<i64>() {
+        match tok.text(self.query).parse::<i128>() {
             Ok(i) => Ok(Some((tok.span, i))),
             Err(e) => Err(Box::new(Error::ParseValue {
                 span: tok.span,
@@ -1206,7 +1206,7 @@ mod tests {
         ),
         (none, int_a10, "a10", Int),
         (none, int_10p1, "10.1", Int),
-        (err, int_overflow, "99999999999999999999"),
+        (err, int_overflow, "170141183460469231731687303715884105728"), // i128::MAX + 1
     );
 
     gen_parse_tests!(
@@ -1577,7 +1577,11 @@ mod tests {
         ),
         (none, int_literal_eof, "", Int),
         (none, int_literal_bool, "true", Int),
-        (err, int_literal_overflow, "99999999999999999999"),
+        (
+            err,
+            int_literal_overflow,
+            "170141183460469231731687303715884105728"
+        ), // i128::MAX + 1
     );
 
     gen_parse_tests!(

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -167,7 +167,7 @@ impl ParamSchema {
 /// A representation of a parameter's default value
 #[derive(Clone, Debug, PartialEq)]
 pub enum DefaultValue {
-    Int(i64),
+    Int(i128),
     Float(f64),
     Str(&'static str),
     Bool(bool),

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -148,7 +148,7 @@ impl ParamSchema {
 
     /// Get the schema for the SQ primitive type of the parameter.
     ///
-    /// This is an SQ primitive type (i.e. Int, Float, Bool or Str).
+    /// This is an SQ primitive type (i.e. I128, ..., F64, Bool or Str).
     pub fn ty(&self) -> PrimitiveKind {
         self.ty
     }
@@ -167,8 +167,12 @@ impl ParamSchema {
 /// A representation of a parameter's default value
 #[derive(Clone, Debug, PartialEq)]
 pub enum DefaultValue {
-    Int(i128),
-    Float(f64),
+    I128(i128),
+    I64(i64),
+    I32(i32),
+    U64(u64),
+    U32(u32),
+    F64(f64),
     Str(&'static str),
     Bool(bool),
     Null,
@@ -178,8 +182,12 @@ impl DefaultValue {
     /// Convert a default value schema into a `Primitive` containing its value.
     pub fn to_primitive(&self) -> Option<Primitive> {
         match self {
-            DefaultValue::Int(i) => Some(Primitive::Int(*i)),
-            DefaultValue::Float(f) => Some(Primitive::Float(*f)),
+            DefaultValue::I128(i) => Some(Primitive::I128(*i)),
+            DefaultValue::I64(i) => Some(Primitive::I64(*i)),
+            DefaultValue::I32(i) => Some(Primitive::I32(*i)),
+            DefaultValue::U64(i) => Some(Primitive::U64(*i)),
+            DefaultValue::U32(i) => Some(Primitive::U32(*i)),
+            DefaultValue::F64(f) => Some(Primitive::F64(*f)),
             DefaultValue::Str(s) => Some(Primitive::Str(s.to_string())),
             DefaultValue::Bool(b) => Some(Primitive::Bool(*b)),
             DefaultValue::Null => None,

--- a/src/sqvalue.rs
+++ b/src/sqvalue.rs
@@ -229,13 +229,13 @@ mod tests {
 
     #[test]
     fn test_dyn_sequence_empty() {
-        let mut empty = DynSequence::<i64>::empty();
+        let mut empty = DynSequence::<i128>::empty();
         assert_eq!(empty.next(), None);
     }
 
     #[test]
     fn test_dyn_sequence_default() {
-        let mut def = DynSequence::<i64>::default();
+        let mut def = DynSequence::<i128>::default();
         assert_eq!(def.next(), None);
     }
 

--- a/src/sqvalue.rs
+++ b/src/sqvalue.rs
@@ -206,23 +206,23 @@ mod tests {
         let mut seq = gen_sqbvalue_seq(seq_type, 5);
         assert_eq!(
             field_call_result_to_primitive(seq.next().unwrap()),
-            Primitive::Int(0)
+            Primitive::I128(0)
         );
         assert_eq!(
             field_call_result_to_primitive(seq.next().unwrap()),
-            Primitive::Int(1)
+            Primitive::I128(1)
         );
         assert_eq!(
             field_call_result_to_primitive(seq.next().unwrap()),
-            Primitive::Int(2)
+            Primitive::I128(2)
         );
         assert_eq!(
             field_call_result_to_primitive(seq.next().unwrap()),
-            Primitive::Int(3)
+            Primitive::I128(3)
         );
         assert_eq!(
             field_call_result_to_primitive(seq.next().unwrap()),
-            Primitive::Int(4)
+            Primitive::I128(4)
         );
         assert!(seq.next().is_none());
     }

--- a/src/system/schema.json
+++ b/src/system/schema.json
@@ -4,7 +4,7 @@
         {
             "name": "SqBool",
             "doc": "A boolean type",
-            "primitive_coercion": "PrimitiveBool",
+            "primitive_coercion": "Bool",
             "fields": [
                 {
                     "name": "not",
@@ -17,26 +17,26 @@
         },
         {
             "name": "SqInt",
-            "doc": "A 64-bit signed integer",
-            "primitive_coercion": "PrimitiveInt",
+            "doc": "A 128-bit signed integer",
+            "primitive_coercion": "I128",
             "fields": []
         },
         {
             "name": "SqFloat",
             "doc": "A double precision floating point type",
-            "primitive_coercion": "PrimitiveFloat",
+            "primitive_coercion": "F64",
             "fields": []
         },
         {
             "name": "SqString",
             "doc": "A string of unicode characters",
-            "primitive_coercion": "PrimitiveString",
+            "primitive_coercion": "Str",
             "fields": []
         },
         {
             "name": "SqSystemTime",
             "doc": "A point in time",
-            "primitive_coercion": "PrimitiveInt",
+            "primitive_coercion": "U64",
             "fields": [
                 {
                     "name": "duration_since_epoch",
@@ -50,7 +50,7 @@
         {
             "name": "SqDuration",
             "doc": "A duration of time",
-            "primitive_coercion": "PrimitiveFloat",
+            "primitive_coercion": "F64",
             "fields": [
                 {
                     "name": "s",
@@ -85,7 +85,7 @@
         {
             "name": "SqDataSize",
             "doc": "A data size",
-            "primitive_coercion": "PrimitiveInt",
+            "primitive_coercion": "U64",
             "fields": [
                 {
                     "name": "B",
@@ -169,7 +169,7 @@
         {
             "name": "SqOsString",
             "doc": "A string in the OS's encoding",
-            "primitive_coercion": "PrimitiveString",
+            "primitive_coercion": "Str",
             "fields": [
                 {
                     "name": "string",
@@ -181,7 +181,7 @@
                             "index": 0,
                             "name": "replace_invalid",
                             "doc": "Replace invalid unicode bytes with � instead of failing.",
-                            "type": "PrimitiveBool",
+                            "type": "Bool",
                             "required": false,
                             "default_value": false
                         }
@@ -192,7 +192,7 @@
         {
             "name": "SqPath",
             "doc": "A filesystem path",
-            "primitive_coercion": "PrimitiveString",
+            "primitive_coercion": "Str",
             "fields": [
                 {
                     "name": "string",
@@ -204,7 +204,7 @@
                             "index": 0,
                             "name": "replace_invalid",
                             "doc": "Replace invalid unicode bytes with � instead of failing.",
-                            "type": "PrimitiveBool",
+                            "type": "Bool",
                             "required": false,
                             "default_value": false
                         }
@@ -311,7 +311,7 @@
                             "index": 0,
                             "name": "recurse",
                             "doc": "Whether recursively list children of subdirectories",
-                            "type": "PrimitiveBool",
+                            "type": "Bool",
                             "required": false,
                             "default_value": false
                         },
@@ -319,7 +319,7 @@
                             "index": 1,
                             "name": "follow_symlinks",
                             "doc": "Whether to dereference symlinks",
-                            "type": "PrimitiveBool",
+                            "type": "Bool",
                             "required": false,
                             "default_value": true
                         },
@@ -327,7 +327,7 @@
                             "index": 2,
                             "name": "skip_permission_denied",
                             "doc": "Whether to skip subdirectories that would otherwise cause permission errors",
-                            "type": "PrimitiveBool",
+                            "type": "Bool",
                             "required": false,
                             "default_value": false
                         },
@@ -335,7 +335,7 @@
                             "index": 3,
                             "name": "same_filesystem",
                             "doc": "Do not cross filesystem boundaries",
-                            "type": "PrimitiveBool",
+                            "type": "Bool",
                             "required": false,
                             "default_value": false
                         }
@@ -400,7 +400,7 @@
                             "index": 0,
                             "name": "follow_symlinks",
                             "doc": "Whether to dereference symlinks",
-                            "type": "PrimitiveBool",
+                            "type": "Bool",
                             "required": false,
                             "default_value": true
                         }
@@ -411,7 +411,7 @@
         {
             "name": "SqFile",
             "doc": "A file",
-            "primitive_coercion": "PrimitiveString",
+            "primitive_coercion": "Str",
             "fields": [
                 {
                     "name": "inode",
@@ -496,7 +496,7 @@
         {
             "name": "SqFileMode",
             "doc": "File mode information. I.e. permissions and SUID, SGID and sticky bits",
-            "primitive_coercion": "PrimitiveInt",
+            "primitive_coercion": "U32",
             "fields": [
                 {
                     "name": "permissions",
@@ -531,7 +531,7 @@
         {
             "name": "SqUser",
             "doc": "A user",
-            "primitive_coercion": "PrimitiveInt",
+            "primitive_coercion": "U32",
             "fields": [
                 {
                     "name": "uid",
@@ -592,7 +592,7 @@
         {
             "name": "SqGroup",
             "doc": "A group",
-            "primitive_coercion": "PrimitiveInt",
+            "primitive_coercion": "U32",
             "fields": [
                 {
                     "name": "gid",
@@ -624,7 +624,7 @@
                 "The SQ root type is the entry point into the system:",
                 "all SQ Queries begin by selecting fields from the SQ root type."
             ],
-            "primitive_coercion": "PrimitiveBool",
+            "primitive_coercion": "Bool",
             "fields": [
                 {
                     "name": "bool",
@@ -636,7 +636,7 @@
                             "index": 0,
                             "name": "value",
                             "doc": "the value of the boolean to get",
-                            "type": "PrimitiveBool",
+                            "type": "Bool",
                             "required": false,
                             "default_value": false
                         }
@@ -652,7 +652,7 @@
                             "index": 0,
                             "name": "value",
                             "doc": "the path to get; default is the current working directory",
-                            "type": "PrimitiveString",
+                            "type": "Str",
                             "required": false,
                             "default_value": null
                         }
@@ -668,7 +668,7 @@
                             "index": 0,
                             "name": "value",
                             "doc": "the value of the integer to get",
-                            "type": "PrimitiveInt",
+                            "type": "I128",
                             "required": false,
                             "default_value": 0
                         }
@@ -696,7 +696,7 @@
                             "index": 0,
                             "name": "start",
                             "doc": "the first integer in the squence",
-                            "type": "PrimitiveInt",
+                            "type": "I128",
                             "required": false,
                             "default_value": 0
                         },
@@ -704,7 +704,7 @@
                             "index": 1,
                             "name": "stop",
                             "doc": "the upper bound for the sequence; default is no upper bound",
-                            "type": "PrimitiveInt",
+                            "type": "I128",
                             "required": false,
                             "default_value": null
                         },
@@ -712,7 +712,7 @@
                             "index": 2,
                             "name": "step",
                             "doc": "distance between each integer returned; must be > 0",
-                            "type": "PrimitiveInt",
+                            "type": "I128",
                             "required": false,
                             "default_value": 1
                         }
@@ -728,7 +728,7 @@
                             "index": 0,
                             "name": "value",
                             "doc": "the value, in bytes, of the data size to get",
-                            "type": "PrimitiveInt",
+                            "type": "U64",
                             "required": false,
                             "default_value": 0
                         }
@@ -744,7 +744,7 @@
                             "index": 0,
                             "name": "value",
                             "doc": "the value of the float to get",
-                            "type": "PrimitiveFloat",
+                            "type": "F64",
                             "required": false,
                             "default_value": 0.0
                         }
@@ -760,7 +760,7 @@
                             "index": 0,
                             "name": "s",
                             "doc": "Seconds to add to the duration",
-                            "type": "PrimitiveInt",
+                            "type": "U64",
                             "required": false,
                             "default_value": 0
                         },
@@ -768,7 +768,7 @@
                             "index": 1,
                             "name": "ms",
                             "doc": "Milliseconds to add to the duration",
-                            "type": "PrimitiveInt",
+                            "type": "U64",
                             "required": false,
                             "default_value": 0
                         },
@@ -776,7 +776,7 @@
                             "index": 2,
                             "name": "us",
                             "doc": "Microseconds to add to the duration",
-                            "type": "PrimitiveInt",
+                            "type": "U64",
                             "required": false,
                             "default_value": 0
                         },
@@ -784,7 +784,7 @@
                             "index": 3,
                             "name": "ns",
                             "doc": "Nanoseconds to add to the duration",
-                            "type": "PrimitiveInt",
+                            "type": "U64",
                             "required": false,
                             "default_value": 0
                         }
@@ -800,7 +800,7 @@
                             "index": 0,
                             "name": "value",
                             "doc": "the value of the string to get",
-                            "type": "PrimitiveString",
+                            "type": "Str",
                             "required": false,
                             "default_value": ""
                         }
@@ -820,7 +820,7 @@
                             "index": 0,
                             "name": "username",
                             "doc": "The username of the user to get",
-                            "type": "PrimitiveString",
+                            "type": "Str",
                             "required": false,
                             "default_value": null
                         },
@@ -828,7 +828,7 @@
                             "index": 1,
                             "name": "uid",
                             "doc": "the UID of the user to get",
-                            "type": "PrimitiveInt",
+                            "type": "U32",
                             "required": false,
                             "default_value": null
                         }
@@ -848,7 +848,7 @@
                             "index": 0,
                             "name": "group_name",
                             "doc": "The name of the group to get",
-                            "type": "PrimitiveString",
+                            "type": "Str",
                             "required": false,
                             "default_value": null
                         },
@@ -856,7 +856,7 @@
                             "index": 1,
                             "name": "gid",
                             "doc": "the GID of the group to get",
-                            "type": "PrimitiveInt",
+                            "type": "U32",
                             "required": false,
                             "default_value": null
                         }

--- a/src/system/sqdatasize.rs
+++ b/src/system/sqdatasize.rs
@@ -2,8 +2,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-use anyhow::anyhow;
-
 use crate::primitive::Primitive;
 use crate::system::{sqfloat::SqFloat, sqint::SqInt, SqDataSizeTrait};
 
@@ -30,23 +28,11 @@ impl SqDataSize {
 
 impl SqDataSizeTrait for SqDataSize {
     fn to_primitive(&self) -> anyhow::Result<Primitive> {
-        match i64::try_from(self.value) {
-            Err(_) => Err(anyhow!(
-                "Failed to convert SqDataSize {}B to 64-bit signed integer",
-                self.value
-            )),
-            Ok(value_i64) => Ok(Primitive::Int(value_i64)),
-        }
+        Ok(Primitive::Int(i128::from(self.value)))
     }
 
     fn b(&self) -> anyhow::Result<SqInt> {
-        match i64::try_from(self.value) {
-            Ok(value_i64) => Ok(SqInt::new(value_i64)),
-            Err(_) => Err(anyhow!(
-                "Failed to convert data size {}B to 64-bit signed integer",
-                self.value
-            )),
-        }
+        Ok(SqInt::from(self.value))
     }
 
     fn kib(&self) -> anyhow::Result<SqFloat> {

--- a/src/system/sqdatasize.rs
+++ b/src/system/sqdatasize.rs
@@ -28,7 +28,7 @@ impl SqDataSize {
 
 impl SqDataSizeTrait for SqDataSize {
     fn to_primitive(&self) -> anyhow::Result<Primitive> {
-        Ok(Primitive::Int(i128::from(self.value)))
+        Ok(Primitive::I128(i128::from(self.value)))
     }
 
     fn b(&self) -> anyhow::Result<SqInt> {

--- a/src/system/sqduration.rs
+++ b/src/system/sqduration.rs
@@ -19,7 +19,7 @@ impl SqDuration {
 
 impl SqDurationTrait for SqDuration {
     fn to_primitive(&self) -> anyhow::Result<Primitive> {
-        Ok(Primitive::Float(self.value.as_secs_f64()))
+        Ok(Primitive::F64(self.value.as_secs_f64()))
     }
 
     fn s(&self) -> anyhow::Result<SqInt> {

--- a/src/system/sqduration.rs
+++ b/src/system/sqduration.rs
@@ -4,8 +4,6 @@
 
 use std::time::Duration;
 
-use anyhow::anyhow;
-
 use crate::primitive::Primitive;
 use crate::system::{sqint::SqInt, SqDurationTrait};
 
@@ -25,26 +23,18 @@ impl SqDurationTrait for SqDuration {
     }
 
     fn s(&self) -> anyhow::Result<SqInt> {
-        let secs_u64 = self.value.as_secs();
-        let Ok(secs_i64) = i64::try_from(secs_u64) else {
-            return Err(anyhow!(
-                "Failed to convert duration in seconds ({}s) to a 64-bit signed integer",
-                secs_u64
-            ));
-        };
-
-        Ok(SqInt::new(secs_i64))
+        Ok(SqInt::from(self.value.as_secs()))
     }
 
     fn subsec_ns(&self) -> anyhow::Result<SqInt> {
-        Ok(SqInt::new(i64::from(self.value.subsec_nanos())))
+        Ok(SqInt::from(self.value.subsec_nanos()))
     }
 
     fn subsec_us(&self) -> anyhow::Result<SqInt> {
-        Ok(SqInt::new(i64::from(self.value.subsec_micros())))
+        Ok(SqInt::from(self.value.subsec_micros()))
     }
 
     fn subsec_ms(&self) -> anyhow::Result<SqInt> {
-        Ok(SqInt::new(i64::from(self.value.subsec_millis())))
+        Ok(SqInt::from(self.value.subsec_millis()))
     }
 }

--- a/src/system/sqfile.rs
+++ b/src/system/sqfile.rs
@@ -59,15 +59,7 @@ impl SqFileTrait for SqFile {
     }
 
     fn inode(&self) -> anyhow::Result<SqInt> {
-        let inode = self.stat.st_ino;
-        match i64::try_from(inode) {
-            Ok(inode_i64) => Ok(SqInt::new(inode_i64)),
-            Err(_) => Err(anyhow!(
-                "Failed to convert inode number {} for {} to 64-bit signed integer",
-                inode,
-                self.path.to_string_lossy()
-            )),
-        }
+        Ok(SqInt::from(self.stat.st_ino))
     }
 
     fn size(&self) -> anyhow::Result<SqDataSize> {
@@ -110,15 +102,7 @@ impl SqFileTrait for SqFile {
     }
 
     fn hard_link_count(&self) -> anyhow::Result<SqInt> {
-        let count = self.stat.st_nlink;
-        match i64::try_from(count) {
-            Ok(count_i64) => Ok(SqInt::new(count_i64)),
-            Err(_) => Err(anyhow!(
-                "Failed to convert hard link count {} for {} to 64-bit signed integer",
-                count,
-                self.path.to_string_lossy()
-            )),
-        }
+        Ok(SqInt::from(self.stat.st_nlink))
     }
 
     fn mode(&self) -> anyhow::Result<SqFileMode> {
@@ -140,7 +124,7 @@ impl SqFileTrait for SqFile {
     }
 
     fn block_count(&self) -> anyhow::Result<SqInt> {
-        Ok(SqInt::new(self.stat.st_blocks))
+        Ok(SqInt::from(self.stat.st_blocks))
     }
 
     fn user(&self) -> anyhow::Result<SqUser> {

--- a/src/system/sqfilemode.rs
+++ b/src/system/sqfilemode.rs
@@ -19,7 +19,7 @@ impl SqFileMode {
 
 impl SqFileModeTrait for SqFileMode {
     fn to_primitive(&self) -> anyhow::Result<Primitive> {
-        Ok(Primitive::Int(i64::from(self.mode.bits())))
+        Ok(Primitive::Int(i128::from(self.mode.bits())))
     }
 
     fn permissions(&self) -> anyhow::Result<SqInt> {
@@ -27,7 +27,7 @@ impl SqFileModeTrait for SqFileMode {
             .mode
             .intersection(Mode::S_IRWXU | Mode::S_IRWXG | Mode::S_IRWXO)
             .bits();
-        Ok(SqInt::new(i64::from(num)))
+        Ok(SqInt::from(num))
     }
 
     fn suid(&self) -> anyhow::Result<SqBool> {

--- a/src/system/sqfilemode.rs
+++ b/src/system/sqfilemode.rs
@@ -19,7 +19,7 @@ impl SqFileMode {
 
 impl SqFileModeTrait for SqFileMode {
     fn to_primitive(&self) -> anyhow::Result<Primitive> {
-        Ok(Primitive::Int(i128::from(self.mode.bits())))
+        Ok(Primitive::I128(i128::from(self.mode.bits())))
     }
 
     fn permissions(&self) -> anyhow::Result<SqInt> {

--- a/src/system/sqfloat.rs
+++ b/src/system/sqfloat.rs
@@ -17,6 +17,6 @@ impl SqFloat {
 
 impl SqFloatTrait for SqFloat {
     fn to_primitive(&self) -> anyhow::Result<Primitive> {
-        Ok(Primitive::Float(self.value))
+        Ok(Primitive::F64(self.value))
     }
 }

--- a/src/system/sqgroup.rs
+++ b/src/system/sqgroup.rs
@@ -38,11 +38,11 @@ impl SqGroup {
 
 impl SqGroupTrait for SqGroup {
     fn to_primitive(&self) -> anyhow::Result<Primitive> {
-        Ok(Primitive::Int(i64::from(self.group.gid.as_raw())))
+        Ok(Primitive::from(self.group.gid.as_raw()))
     }
 
     fn gid(&self) -> anyhow::Result<SqInt> {
-        Ok(SqInt::new(i64::from(self.group.gid.as_raw())))
+        Ok(SqInt::from(self.group.gid.as_raw()))
     }
 
     fn name(&self) -> anyhow::Result<SqString> {

--- a/src/system/sqint.rs
+++ b/src/system/sqint.rs
@@ -6,11 +6,11 @@ use crate::primitive::Primitive;
 use crate::system::SqIntTrait;
 
 pub struct SqInt {
-    value: i64,
+    value: i128,
 }
 
 impl SqInt {
-    pub fn new(value: i64) -> Self {
+    pub fn new(value: i128) -> Self {
         Self { value }
     }
 }
@@ -18,5 +18,14 @@ impl SqInt {
 impl SqIntTrait for SqInt {
     fn to_primitive(&self) -> anyhow::Result<Primitive> {
         Ok(Primitive::Int(self.value))
+    }
+}
+
+impl<T> From<T> for SqInt
+where
+    i128: From<T>,
+{
+    fn from(v: T) -> Self {
+        Self::new(i128::from(v))
     }
 }

--- a/src/system/sqint.rs
+++ b/src/system/sqint.rs
@@ -17,7 +17,7 @@ impl SqInt {
 
 impl SqIntTrait for SqInt {
     fn to_primitive(&self) -> anyhow::Result<Primitive> {
-        Ok(Primitive::Int(self.value))
+        Ok(Primitive::I128(self.value))
     }
 }
 

--- a/src/system/sqroot.rs
+++ b/src/system/sqroot.rs
@@ -53,26 +53,26 @@ impl SqRootTrait for SqRoot {
         }
     }
 
-    fn int(&self, p_value: Option<i64>) -> anyhow::Result<SqInt> {
+    fn int(&self, p_value: Option<i128>) -> anyhow::Result<SqInt> {
         Ok(SqInt::new(p_value.unwrap_or(0)))
     }
 
     fn ints(
         &self,
-        start: Option<i64>,
-        stop: Option<i64>,
-        step: Option<i64>,
+        start: Option<i128>,
+        stop: Option<i128>,
+        step: Option<i128>,
     ) -> anyhow::Result<SqValueSequence<SqInt>> {
         let start = start.unwrap_or(0);
-        let step_i64 = step.unwrap_or(1);
-        let step: usize = step_i64
+        let step_i128 = step.unwrap_or(1);
+        let step: usize = step_i128
             .try_into()
-            .map_err(|_| anyhow!("Invalid step option{}: must be > 0", step_i64))?;
+            .map_err(|_| anyhow!("Failed to convert step option {} to usize type", step_i128))?;
         ensure!(step > 0, "Invalid step option {}: must be > 0", step);
         // Only return an Iterator because:
-        // * Range<i64> isn't an ExactSizeIterator because on 32-bit platforms the size hint (a
-        //   usize) might not be big enough to hold the size of the range.
-        // * Range<i64> isn't a DoubleEndedIterator because the range could be infinite.
+        // * Range<i128> isn't an ExactSizeIterator because the size hint (a usize) might not be
+        // big enough to hold the size of the range.
+        // * Range<i128> isn't a DoubleEndedIterator because the range could be infinite.
         //
         // Perhaps we could add special cases for when the size fits into a usize. This field
         // probably isn't particularly useful for real-world applications though so it's probably
@@ -93,10 +93,10 @@ impl SqRootTrait for SqRoot {
 
     fn duration(
         &self,
-        s: Option<i64>,
-        ms: Option<i64>,
-        us: Option<i64>,
-        ns: Option<i64>,
+        s: Option<i128>,
+        ms: Option<i128>,
+        us: Option<i128>,
+        ns: Option<i128>,
     ) -> anyhow::Result<SqDuration> {
         let s_duration = Duration::from_secs(
             u64::try_from(s.unwrap_or(0)).map_err(|_| anyhow!("s argument must be nonnegative"))?,
@@ -125,7 +125,7 @@ impl SqRootTrait for SqRoot {
         }
     }
 
-    fn data_size(&self, value: Option<i64>) -> anyhow::Result<SqDataSize> {
+    fn data_size(&self, value: Option<i128>) -> anyhow::Result<SqDataSize> {
         let value = value.unwrap_or(0);
         match u64::try_from(value) {
             Ok(v) => Ok(SqDataSize::new(v)),
@@ -133,7 +133,7 @@ impl SqRootTrait for SqRoot {
         }
     }
 
-    fn user(&self, opt_username: Option<&str>, opt_uid: Option<i64>) -> anyhow::Result<SqUser> {
+    fn user(&self, opt_username: Option<&str>, opt_uid: Option<i128>) -> anyhow::Result<SqUser> {
         if let Some(username) = opt_username {
             if opt_uid.is_some() {
                 return Err(anyhow!(
@@ -156,7 +156,11 @@ impl SqRootTrait for SqRoot {
         SqUser::real()
     }
 
-    fn group(&self, opt_group_name: Option<&str>, opt_gid: Option<i64>) -> anyhow::Result<SqGroup> {
+    fn group(
+        &self,
+        opt_group_name: Option<&str>,
+        opt_gid: Option<i128>,
+    ) -> anyhow::Result<SqGroup> {
         if let Some(group_name) = opt_group_name {
             if opt_gid.is_some() {
                 return Err(anyhow!(

--- a/src/system/sqroot.rs
+++ b/src/system/sqroot.rs
@@ -93,26 +93,15 @@ impl SqRootTrait for SqRoot {
 
     fn duration(
         &self,
-        s: Option<i128>,
-        ms: Option<i128>,
-        us: Option<i128>,
-        ns: Option<i128>,
+        s: Option<u64>,
+        ms: Option<u64>,
+        us: Option<u64>,
+        ns: Option<u64>,
     ) -> anyhow::Result<SqDuration> {
-        let s_duration = Duration::from_secs(
-            u64::try_from(s.unwrap_or(0)).map_err(|_| anyhow!("s argument must be nonnegative"))?,
-        );
-        let ms_duration = Duration::from_millis(
-            u64::try_from(ms.unwrap_or(0))
-                .map_err(|_| anyhow!("ms argument must be nonnegative"))?,
-        );
-        let us_duration = Duration::from_micros(
-            u64::try_from(us.unwrap_or(0))
-                .map_err(|_| anyhow!("us argument must be nonnegative"))?,
-        );
-        let ns_duration = Duration::from_nanos(
-            u64::try_from(ns.unwrap_or(0))
-                .map_err(|_| anyhow!("ns argument must be nonnegative"))?,
-        );
+        let s_duration = Duration::from_secs(s.unwrap_or(0));
+        let ms_duration = Duration::from_millis(ms.unwrap_or(0));
+        let us_duration = Duration::from_micros(us.unwrap_or(0));
+        let ns_duration = Duration::from_nanos(ns.unwrap_or(0));
 
         let opt_duration = s_duration
             .checked_add(ms_duration)
@@ -125,15 +114,11 @@ impl SqRootTrait for SqRoot {
         }
     }
 
-    fn data_size(&self, value: Option<i128>) -> anyhow::Result<SqDataSize> {
-        let value = value.unwrap_or(0);
-        match u64::try_from(value) {
-            Ok(v) => Ok(SqDataSize::new(v)),
-            Err(_) => Err(anyhow!("Data size value must be non-negative")),
-        }
+    fn data_size(&self, value: Option<u64>) -> anyhow::Result<SqDataSize> {
+        Ok(SqDataSize::new(value.unwrap_or(0)))
     }
 
-    fn user(&self, opt_username: Option<&str>, opt_uid: Option<i128>) -> anyhow::Result<SqUser> {
+    fn user(&self, opt_username: Option<&str>, opt_uid: Option<u32>) -> anyhow::Result<SqUser> {
         if let Some(username) = opt_username {
             if opt_uid.is_some() {
                 return Err(anyhow!(
@@ -142,25 +127,13 @@ impl SqRootTrait for SqRoot {
             }
             return SqUser::from_name(username);
         }
-        if let Some(uid) = opt_uid {
-            return match u32::try_from(uid) {
-                Ok(u32uid) => SqUser::from_uid(u32uid),
-                Err(_) => Err(anyhow!(
-                    "uid argument {} must be in the range [{},{})",
-                    uid,
-                    0,
-                    u32::MAX
-                )),
-            };
+        match opt_uid {
+            Some(uid) => SqUser::from_uid(uid),
+            None => SqUser::real(),
         }
-        SqUser::real()
     }
 
-    fn group(
-        &self,
-        opt_group_name: Option<&str>,
-        opt_gid: Option<i128>,
-    ) -> anyhow::Result<SqGroup> {
+    fn group(&self, opt_group_name: Option<&str>, opt_gid: Option<u32>) -> anyhow::Result<SqGroup> {
         if let Some(group_name) = opt_group_name {
             if opt_gid.is_some() {
                 return Err(anyhow!(
@@ -169,17 +142,9 @@ impl SqRootTrait for SqRoot {
             }
             return SqGroup::from_name(group_name);
         }
-        if let Some(gid) = opt_gid {
-            return match u32::try_from(gid) {
-                Ok(u32gid) => SqGroup::from_gid(u32gid),
-                Err(_) => Err(anyhow!(
-                    "gid argument {} must be in the range [{},{})",
-                    gid,
-                    0,
-                    u32::MAX
-                )),
-            };
+        match opt_gid {
+            Some(gid) => SqGroup::from_gid(gid),
+            None => SqGroup::real(),
         }
-        SqGroup::real()
     }
 }

--- a/src/system/sqsystemtime.rs
+++ b/src/system/sqsystemtime.rs
@@ -47,15 +47,7 @@ impl SqSystemTime {
 
 impl SqSystemTimeTrait for SqSystemTime {
     fn to_primitive(&self) -> anyhow::Result<Primitive> {
-        let secs_u64 = self.since_epoch()?.as_secs();
-        let Ok(secs_i64) = i64::try_from(secs_u64) else {
-            return Err(anyhow!(
-                "Failed to convert UNIX timestamp {} to a 64-bit signed integer",
-                secs_u64
-            ));
-        };
-
-        Ok(Primitive::Int(secs_i64))
+        Ok(Primitive::from(self.since_epoch()?.as_secs()))
     }
 
     fn duration_since_epoch(&self) -> anyhow::Result<SqDuration> {

--- a/src/system/squser.rs
+++ b/src/system/squser.rs
@@ -51,11 +51,11 @@ impl SqUser {
 
 impl SqUserTrait for SqUser {
     fn to_primitive(&self) -> anyhow::Result<Primitive> {
-        Ok(Primitive::Int(i64::from(self.user.uid.as_raw())))
+        Ok(Primitive::from(self.user.uid.as_raw()))
     }
 
     fn uid(&self) -> anyhow::Result<SqInt> {
-        Ok(SqInt::new(i64::from(self.user.uid.as_raw())))
+        Ok(SqInt::from(self.user.uid.as_raw()))
     }
 
     fn username(&self) -> anyhow::Result<SqString> {

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -114,7 +114,7 @@ pub fn get_seq_type<T>(seq: &DynSequence<T>) -> SequenceType {
     }
 }
 
-pub fn fake_int_literal(value: i64) -> ast::IntLiteral {
+pub fn fake_int_literal(value: i128) -> ast::IntLiteral {
     ast::IntLiteral {
         span: (0, 0).into(),
         value,

--- a/src/util.rs
+++ b/src/util.rs
@@ -32,14 +32,14 @@ macro_rules! return_none_or_err {
 }
 pub(crate) use return_none_or_err;
 
-/// A trait to be implemented by types for which a `&T` can sometimes be obtained.
-///
-/// Unlike `std::convert::AsRef::as_ref()`, `TryAsRef::try_as_ref()` can fail.
+pub trait TryAs<T> {
+    type Error;
+    fn try_as(&self) -> StdResult<T, Self::Error>;
+}
+
 pub trait TryAsRef<T: ?Sized> {
-    /// Try to borrow self as a`&T`.
-    ///
-    /// If the conversion fails, `None` is returned.
-    fn try_as_ref(&self) -> Option<&T>;
+    type Error;
+    fn try_as_ref(&self) -> StdResult<&T, Self::Error>;
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, ThisError)]

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -10,8 +10,8 @@ test_simple_query_err!(
     errors,
     lex, "&", Lex;
     unexpected_token, "true", UnexpectedToken;
-    int_too_big, "int(9223372036854775808)", ParseValue; // i64::MAX + 1
-    int_too_small, "int(-9223372036854775809)", ParseValue; // i64::MAX + 1
+    int_too_big, "int(170141183460469231731687303715884105728)", ParseValue; // i128::MAX + 1
+    int_too_small, "int(-170141183460469231731687303715884105729)", ParseValue; // i128::MIN - 1
     float_too_big, "float(10.0E+308)", ParseValue;
     float_too_small, "float(10.0E+308)", ParseValue;
     invalid_string, r#"string("\uxxxx")"#, ParseValue;

--- a/tests/sqfile.rs
+++ b/tests/sqfile.rs
@@ -14,7 +14,7 @@ fn sqfile_inode() {
     let temp_files = TempFiles::new().file("file1").link("file1", "file2");
     let query1 = format!("<path(\"{}\").<file.<inode", &temp_files[0]);
     let query2 = format!("<path(\"{}\").<file.<inode", &temp_files[1]);
-    assert_eq!(get_query_as::<i64>(&query1), get_query_as::<i64>(&query2));
+    assert_eq!(get_query_as::<i128>(&query1), get_query_as::<i128>(&query2));
 }
 
 #[rstest]

--- a/tests/sqroot.rs
+++ b/tests/sqroot.rs
@@ -49,10 +49,10 @@ test_simple_query_approx_f64_ulp!(
 
 test_simple_query_err!(
     sqroot_duration_err,
-    neg_secs, "duration(s=-1)", System;
-    neg_millis, "duration(ms=-1)", System;
-    neg_micros, "duration(us=-1)", System;
-    neg_nanos, "duration(ns=-1)", System;
+    neg_secs, "duration(s=-1)", ConvertIntegerArg;
+    neg_millis, "duration(ms=-1)", ConvertIntegerArg;
+    neg_micros, "duration(us=-1)", ConvertIntegerArg;
+    neg_nanos, "duration(ns=-1)", ConvertIntegerArg;
 );
 
 test_simple_query_ok!(
@@ -64,8 +64,8 @@ test_simple_query_ok!(
 
 test_simple_query_err!(
     sqroot_data_size_err,
-    minus_one, "<data_size(-1)", System;
-    i64_min, "<data_size(-9223372036854775808)", System;
+    minus_one, "<data_size(-1)", ConvertIntegerArg;
+    i64_min, "<data_size(-9223372036854775808)", ConvertIntegerArg;
 );
 
 test_simple_query_ok!(
@@ -133,7 +133,7 @@ test_simple_query_ok!(
 
 test_simple_query_err!(
     sqroot_user_err,
-    invalid_uid, "user(uid=4294967296)", System; // u32::MAX + 1
+    invalid_uid, "user(uid=4294967296)", ConvertIntegerArg; // u32::MAX + 1
 );
 
 #[test]
@@ -186,5 +186,5 @@ test_simple_query_ok!(
 
 test_simple_query_err!(
     sqroot_group_err,
-    invalid_gid, "group(gid=4294967296)", System; // u32::MAX + 1
+    invalid_gid, "group(gid=4294967296)", ConvertIntegerArg; // u32::MAX + 1
 );


### PR DESCRIPTION
Add primitives I128, I64, I32, U64 and U32.

Literal values in the AST will always be I128s because we don't know the
specific integer types of field call params at parse time.

Also:
* Rename the Float primitive type to F64 to be consistent with the names
  of the integer types.
* Remove the "Primitive" prefix from the names of the primitive types in
  the schema and in debug output because it's redundant.