### PR TITLE
Validate field call args before generating results

### DIFF
--- a/src/filter/index.rs
+++ b/src/filter/index.rs
@@ -241,7 +241,7 @@ mod tests {
         #[case] expected: Option<i128>,
     ) {
         let field_call_ast = fake_field_call_ast();
-        let call_info = FieldCallInfo::new(&field_call_ast, schema::root_field());
+        let call_info = FieldCallInfo::new(&field_call_ast, schema::root_field()).unwrap();
         let seq = gen_sqbvalue_seq(seq_type, seq_len);
         let int_literal = fake_int_literal(index);
         let filter = IndexFilter::new(&call_info, &int_literal);

--- a/src/filter/slice.rs
+++ b/src/filter/slice.rs
@@ -999,7 +999,7 @@ mod tests {
         seq_len: usize,
     ) -> std::result::Result<(), String> {
         let field_call_ast = fake_field_call_ast();
-        let call_info = FieldCallInfo::new(&field_call_ast, schema::root_field());
+        let call_info = FieldCallInfo::new(&field_call_ast, schema::root_field()).unwrap();
         let seq = gen_sqbvalue_seq(seq_type, seq_len);
         let slice_ast = fake_slice(start, stop, step);
         let filter = SliceFilter::new(&call_info, &slice_ast);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -399,16 +399,6 @@ impl<'q> Parser<'q> {
         }
 
         if let Some(named_arg) = self.parse_named_arg()? {
-            if let Some(prev) = named_args
-                .iter()
-                .find(|na| na.ident.name == named_arg.ident.name)
-            {
-                return Err(Box::new(Error::RepeatedNamedArg {
-                    span: named_arg.span,
-                    name: named_arg.ident.name.clone(),
-                    prev_span: prev.span,
-                }));
-            }
             named_args.push(named_arg);
             return Ok(Some(()));
         }

--- a/src/sqvalue.rs
+++ b/src/sqvalue.rs
@@ -251,7 +251,7 @@ mod tests {
     ) {
         let sqint_seq = gen_sqint_seq(seq_type, 5);
         let field_call_ast = fake_field_call_ast();
-        let call_info = FieldCallInfo::new(&field_call_ast, schema::root_field());
+        let call_info = FieldCallInfo::new(&field_call_ast, schema::root_field()).unwrap();
         let sqbvalue_seq =
             SqBValueSequence::from_sq_value_sequence(gen_sqint_seq(seq_type, 5), &call_info);
 

--- a/src/system/schema.json
+++ b/src/system/schema.json
@@ -838,7 +838,7 @@
                     "name": "group",
                     "doc": [
                         "Get an SqGroup system object",
-                        "The group to get can be specified by either the `group_name` parameter or the `gid` parameter, but not both.",
+                        "The group to get can be specified by either the `name` parameter or the `gid` parameter, but not both.",
                         "If neither `grou_name` nor `gid` are given, then the (real, not effective) group of the current process is retreived."
                     ],
                     "return_type": "SqGroup",
@@ -846,7 +846,7 @@
                     "params": [
                         {
                             "index": 0,
-                            "name": "group_name",
+                            "name": "name",
                             "doc": "The name of the group to get",
                             "type": "Str",
                             "required": false,

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -76,7 +76,7 @@ pub fn gen_sqint_seq(seq_type: SequenceType, len: usize) -> SqValueSequence<'sta
 
 pub fn sqbvalue_to_primitive(sqbvalue: SqBValue) -> Primitive {
     let field_call_ast = fake_field_call_ast();
-    let call_info = FieldCallInfo::new(&field_call_ast, schema::root_field());
+    let call_info = FieldCallInfo::new(&field_call_ast, schema::root_field()).unwrap();
     sqbvalue.get_primitive(&call_info).unwrap()
 }
 
@@ -86,7 +86,7 @@ pub fn field_call_result_to_primitive(result: Result<SqBValue>) -> Primitive {
 
 fn sqbvalue_seq_to_vec_of_opt_prims(seq: SqBValueSequence) -> Vec<Option<Primitive>> {
     let field_call_ast = fake_field_call_ast();
-    let call_info = FieldCallInfo::new(&field_call_ast, schema::root_field());
+    let call_info = FieldCallInfo::new(&field_call_ast, schema::root_field()).unwrap();
     seq.map(|result| result.ok().map(|v| v.get_primitive(&call_info).unwrap()))
         .collect::<Vec<_>>()
 }

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -15,7 +15,10 @@ test_simple_query_err!(
     float_too_big, "float(10.0E+308)", ParseValue;
     float_too_small, "float(10.0E+308)", ParseValue;
     invalid_string, r#"string("\uxxxx")"#, ParseValue;
-    repeated_named_arg, "int(value=10, value=20)", RepeatedNamedArg;
+    repeated_named_arg, "ints(start=10, start=20)", RepeatedArg;
+    repeated_pos_then_named_arg, "ints(10, start=20)", RepeatedArg;
+    too_many_args, "int(10, 10)", TooManyArgs;
+    invalid_arg_name, "int(abcd=10)", InvalidArgName;
     arg_type_mismatch, "int(true)", ArgTypeMismatch;
     invalid_field, "xyzabc", InvalidField;
     invalid_field_on_root, "xyzabc", InvalidField;

--- a/tests/sqroot.rs
+++ b/tests/sqroot.rs
@@ -174,13 +174,13 @@ fn sqroot_group_by_gid() {
 fn sqroot_group_by_both_gid_and_name_err() {
     let gid_json = get_query("<user.<group.<gid").unwrap();
     let name_json = get_query("<user.<group.<name").unwrap();
-    let query = format!("<group(gid={}, group_name={})", gid_json, name_json);
+    let query = format!("<group(gid={}, name={})", gid_json, name_json);
     test_query_err(&query, ErrorKind::System);
 }
 
 test_simple_query_ok!(
     sqroot_group,
-    root_by_name, "<group(group_name=\"root\").<gid", json!(0);
+    root_by_name, "<group(name=\"root\").<gid", json!(0);
     root_by_gid, "<group(gid=0).<name", json!("root");
 );
 


### PR DESCRIPTION
* Add arg validation to FieldCallInfo::new().
* Add a check that all args given to a field call are valid.
* Move existing other arg checks to FieldCallInfo::new() so that errors can be found before we start generating results.
* Improve the error message when an argument is given multiple times.

For #3: Check for invalid args to field calls