### PR TITLE
Add tests for comparison filters

### DIFF
--- a/src/system/schema.json
+++ b/src/system/schema.json
@@ -19,7 +19,15 @@
             "name": "SqInt",
             "doc": "A 128-bit signed integer",
             "primitive_coercion": "I128",
-            "fields": []
+            "fields": [
+                {
+                    "name": "string",
+                    "doc": "Format the integer as a string",
+                    "return_type": "SqString",
+                    "return_sequence_type": "Single",
+                    "params": []
+                }
+            ]
         },
         {
             "name": "SqFloat",

--- a/src/system/sqint.rs
+++ b/src/system/sqint.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 use crate::primitive::Primitive;
-use crate::system::SqIntTrait;
+use crate::system::{sqstring::SqString, SqIntTrait};
 
 pub struct SqInt {
     value: i128,
@@ -18,6 +18,10 @@ impl SqInt {
 impl SqIntTrait for SqInt {
     fn to_primitive(&self) -> anyhow::Result<Primitive> {
         Ok(Primitive::I128(self.value))
+    }
+
+    fn string(&self) -> anyhow::Result<SqString> {
+        Ok(SqString::new(self.value.to_string()))
     }
 }
 

--- a/tests/comparison_filter.rs
+++ b/tests/comparison_filter.rs
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2023 Jonathan Haigh <jonathanhaigh@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+mod integration_test_util;
+
+use integration_test_util::test_simple_query_ok;
+
+test_simple_query_ok!(
+    int_comparison,
+    lt, "<ints(0, 10)[<5]", json!([0, 1, 2, 3, 4]);
+    lte, "<ints(0, 10)[<=5]", json!([0, 1, 2, 3, 4, 5]);
+    gt, "<ints(0, 10)[>5]", json!([6, 7, 8, 9]);
+    gte, "<ints(0, 10)[>=5]", json!([5, 6, 7, 8, 9]);
+    eq, "<ints(0, 10)[=5]", json!([5]);
+    ne, "<ints(0, 10)[!=5]", json!([0, 1, 2, 3, 4, 6, 7, 8, 9]);
+);
+
+// Note that when compared as strings, "10" < "11" < "8" < "9".
+test_simple_query_ok!(
+    str_comparison,
+    lt, r#"<ints(8, 12)[string<"9"]"#, json!([8, 10, 11]);
+    lte, r#"<ints(8, 12)[string<="8"]"#, json!([8, 10, 11]);
+    gt, r#"<ints(8, 12)[string>"10"]"#, json!([8, 9, 11]);
+    gte, r#"<ints(8, 12)[string>="11"]"#, json!([8, 9, 11]);
+    eq, r#"<ints(8, 12)[string="10"]"#, json!([10]);
+    ne, r#"<ints(8, 12)[string!="10"]"#, json!([8, 9, 11]);
+);
+
+// TODO: test f64 comparisons when we have a way to generate a list of floats.
+// TODO: test bool comparisons when we have a way to generate a list of bools.


### PR DESCRIPTION
There aren't currently any fields that return lists of floats or bools,
so omit testing of comparisons against floats or bools, for now.

Add the `SqInt::string` field in order to test string comparisons.

For https://github.com/jonathanhaigh/sqr/issues/21: Add tests for comparison filters.