### PR TITLE
Add methods to get filesystem information

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -11,6 +11,7 @@ pub mod sqdatasize;
 pub mod sqduration;
 pub mod sqfile;
 pub mod sqfilemode;
+pub mod sqfilesystem;
 pub mod sqfloat;
 pub mod sqgroup;
 pub mod sqint;

--- a/src/system/schema.json
+++ b/src/system/schema.json
@@ -518,6 +518,13 @@
                             "default_value": true
                         }
                     ]
+                },
+                {
+                    "name": "filesystem",
+                    "doc": "Get the filesystem on which the path resides",
+                    "return_type": "SqFilesystem",
+                    "return_sequence_type": "Single",
+                    "params": []
                 }
             ]
         },
@@ -601,6 +608,90 @@
                     "name": "group",
                     "doc": "Get the file's group",
                     "return_type": "SqGroup",
+                    "return_sequence_type": "Single",
+                    "params": []
+                },
+                {
+                    "name": "filesystem",
+                    "doc": "Get the file's filesystem",
+                    "return_type": "SqFilesystem",
+                    "return_sequence_type": "Single",
+                    "params": []
+                }
+            ]
+        },
+        {
+            "name": "SqFilesystem",
+            "doc": "A filesystem",
+            "primitive_coercion": "U64",
+            "fields": [
+                {
+                    "name": "id",
+                    "doc": "Get the ID of the filesystem (according to statvfs(3))",
+                    "return_type": "SqInt",
+                    "return_sequence_type": "Single",
+                    "params": []
+                },
+                {
+                    "name": "block_size",
+                    "doc": "Get the block size of the filesystem",
+                    "return_type": "SqDataSize",
+                    "return_sequence_type": "Single",
+                    "params": []
+                },
+                {
+                    "name": "blocks",
+                    "doc": "Get the number of blocks on the filesystem",
+                    "return_type": "SqInt",
+                    "return_sequence_type": "Single",
+                    "params": []
+                },
+                {
+                    "name": "blocks_available",
+                    "doc": "Get the number of available blocks on the filesystem",
+                    "return_type": "SqInt",
+                    "return_sequence_type": "Single",
+                    "params": []
+                },
+                {
+                    "name": "blocks_used",
+                    "doc": "Get the number of used blocks on the filesystem",
+                    "return_type": "SqInt",
+                    "return_sequence_type": "Single",
+                    "params": []
+                },
+                {
+                    "name": "size",
+                    "doc": "Get the size of the filesystem",
+                    "return_type": "SqDataSize",
+                    "return_sequence_type": "Single",
+                    "params": []
+                },
+                {
+                    "name": "space_available",
+                    "doc": "Get the amount of available space on the filesystem",
+                    "return_type": "SqDataSize",
+                    "return_sequence_type": "Single",
+                    "params": []
+                },
+                {
+                    "name": "space_used",
+                    "doc": "Get the amount of used space on the filesystem",
+                    "return_type": "SqDataSize",
+                    "return_sequence_type": "Single",
+                    "params": []
+                },
+                {
+                    "name": "percent_available",
+                    "doc": "Get the percentage space on the filesystem that is available",
+                    "return_type": "SqFloat",
+                    "return_sequence_type": "Single",
+                    "params": []
+                },
+                {
+                    "name": "percent_used",
+                    "doc": "Get the percentage space on the filesystem that is used",
+                    "return_type": "SqFloat",
                     "return_sequence_type": "Single",
                     "params": []
                 }

--- a/src/system/sqdatasize.rs
+++ b/src/system/sqdatasize.rs
@@ -75,3 +75,12 @@ impl SqDataSizeTrait for SqDataSize {
         Ok(SqFloat::new(self.value as f64 / PB))
     }
 }
+
+impl<T> From<T> for SqDataSize
+where
+    u64: From<T>,
+{
+    fn from(value: T) -> Self {
+        Self::new(u64::from(value))
+    }
+}

--- a/src/system/sqfile.rs
+++ b/src/system/sqfile.rs
@@ -9,8 +9,8 @@ use nix::sys::stat;
 
 use crate::primitive::Primitive;
 use crate::system::{
-    sqdatasize::SqDataSize, sqfilemode::SqFileMode, sqgroup::SqGroup, sqint::SqInt,
-    sqstring::SqString, sqsystemtime::SqSystemTime, squser::SqUser, SqFileTrait,
+    sqdatasize::SqDataSize, sqfilemode::SqFileMode, sqfilesystem::SqFilesystem, sqgroup::SqGroup,
+    sqint::SqInt, sqstring::SqString, sqsystemtime::SqSystemTime, squser::SqUser, SqFileTrait,
 };
 
 pub struct SqFile {
@@ -133,5 +133,9 @@ impl SqFileTrait for SqFile {
 
     fn group(&self) -> anyhow::Result<SqGroup> {
         SqGroup::from_gid(self.stat.st_gid)
+    }
+
+    fn filesystem(&self) -> anyhow::Result<SqFilesystem> {
+        SqFilesystem::from_path(self.path.as_ref())
     }
 }

--- a/src/system/sqfilesystem.rs
+++ b/src/system/sqfilesystem.rs
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: 2023 Jonathan Haigh <jonathanhaigh@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+use std::path::Path;
+
+use anyhow::anyhow;
+use nix::sys::statvfs::{statvfs, Statvfs};
+
+use crate::primitive::Primitive;
+use crate::system::{sqdatasize::SqDataSize, sqfloat::SqFloat, sqint::SqInt, SqFilesystemTrait};
+
+pub struct SqFilesystem {
+    statvfs: Statvfs,
+}
+
+impl SqFilesystem {
+    pub fn from_path(path: &Path) -> anyhow::Result<Self> {
+        Ok(Self {
+            statvfs: statvfs(path).map_err(|e| {
+                anyhow!(
+                    "Failed to get filesystem information for path {}: statvfs(3) failed: {}",
+                    path.to_string_lossy().into_owned(),
+                    e
+                )
+            })?,
+        })
+    }
+
+    fn block_count_to_size(&self, block_count: u64) -> anyhow::Result<SqDataSize> {
+        let block_size = self.statvfs.fragment_size();
+        match block_count.checked_mul(block_size) {
+            Some(size) => Ok(SqDataSize::from(size)),
+            None => Err(anyhow!(
+                "Cannot fit size ({} block size * {} blocks) into unsigned 64-bit integer",
+                block_size,
+                block_count
+            )),
+        }
+    }
+
+    fn block_count_to_percent(&self, block_count: u64) -> anyhow::Result<SqFloat> {
+        Ok(SqFloat::new(
+            100f64 * (block_count as f64) / (self.statvfs.blocks() as f64),
+        ))
+    }
+
+    fn blocks_used_u64(&self) -> u64 {
+        let blocks = self.statvfs.blocks();
+        let available = self.statvfs.blocks_available();
+        assert!(blocks > available);
+        blocks - available
+    }
+}
+
+impl SqFilesystemTrait for SqFilesystem {
+    fn to_primitive(&self) -> anyhow::Result<Primitive> {
+        Ok(Primitive::from(self.statvfs.filesystem_id()))
+    }
+
+    fn id(&self) -> anyhow::Result<SqInt> {
+        Ok(SqInt::from(self.statvfs.filesystem_id()))
+    }
+
+    fn block_size(&self) -> anyhow::Result<SqDataSize> {
+        Ok(SqDataSize::from(self.statvfs.fragment_size()))
+    }
+
+    fn blocks(&self) -> anyhow::Result<SqInt> {
+        Ok(SqInt::from(self.statvfs.blocks()))
+    }
+
+    fn blocks_available(&self) -> anyhow::Result<SqInt> {
+        Ok(SqInt::from(self.statvfs.blocks_available()))
+    }
+
+    fn blocks_used(&self) -> anyhow::Result<SqInt> {
+        Ok(SqInt::from(self.blocks_used_u64()))
+    }
+
+    fn size(&self) -> anyhow::Result<SqDataSize> {
+        self.block_count_to_size(self.statvfs.blocks())
+    }
+
+    fn space_available(&self) -> anyhow::Result<SqDataSize> {
+        self.block_count_to_size(self.statvfs.blocks_available())
+    }
+
+    fn space_used(&self) -> anyhow::Result<SqDataSize> {
+        self.block_count_to_size(self.blocks_used_u64())
+    }
+
+    fn percent_available(&self) -> anyhow::Result<SqFloat> {
+        self.block_count_to_percent(self.statvfs.blocks_available())
+    }
+
+    fn percent_used(&self) -> anyhow::Result<SqFloat> {
+        self.block_count_to_percent(self.blocks_used_u64())
+    }
+}

--- a/src/system/sqpath.rs
+++ b/src/system/sqpath.rs
@@ -13,7 +13,8 @@ use walkdir::WalkDir;
 use crate::primitive::Primitive;
 use crate::sqvalue::SqValueSequence;
 use crate::system::{
-    sqbool::SqBool, sqfile::SqFile, sqosstring::SqOsString, sqstring::SqString, SqPathTrait,
+    sqbool::SqBool, sqfile::SqFile, sqfilesystem::SqFilesystem, sqosstring::SqOsString,
+    sqstring::SqString, SqPathTrait,
 };
 
 pub struct SqPath {
@@ -142,5 +143,9 @@ impl SqPathTrait for SqPath {
                 e
             )),
         }
+    }
+
+    fn filesystem(&self) -> anyhow::Result<SqFilesystem> {
+        SqFilesystem::from_path(self.path.as_ref())
     }
 }

--- a/tests/sqfilesystem.rs
+++ b/tests/sqfilesystem.rs
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: 2023 Jonathan Haigh <jonathanhaigh@gmail.com>
+//
+// SPDX-License-Identifier: MIT
+
+use std::process::Command;
+
+use serde::Deserialize;
+use serde_json::json;
+
+use integration_test_util::{get_query_as, test_query_ok};
+
+mod integration_test_util;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum StatfsField {
+    FundamentalBlockSize,
+    AvailableBlocks,
+    TotalBlocks,
+}
+
+impl StatfsField {
+    pub fn escape_code(&self) -> &'static str {
+        match self {
+            Self::AvailableBlocks => "%a",
+            Self::TotalBlocks => "%b",
+            Self::FundamentalBlockSize => "%S",
+        }
+    }
+}
+
+// TODO: test SqFilesystem::id. The ID returned by "stat -f" is different (or encoded differently)
+// to the ID returned by statvfs(3)...
+
+fn get_statfs_field(path: &str, field: StatfsField) -> String {
+    let field_escape = field.escape_code();
+    let args = ["-f", "-c", &field_escape, path];
+    let output = Command::new("stat")
+        .args(args)
+        .output()
+        .expect("failed to call stat(1)");
+    if !output.status.success() {
+        panic!(
+            "Command stat with args {:?}, failed with code {:?}, stdout {} and stderr {}",
+            args,
+            output.status.code(),
+            String::from_utf8_lossy(output.stdout.as_slice()),
+            String::from_utf8_lossy(output.stderr.as_slice())
+        );
+    }
+    String::from_utf8(output.stdout).expect("Failed to decode stat(1) output as UTF-8")
+}
+
+fn get_statfs_u64_field(path: &str, field: StatfsField) -> u64 {
+    let field_str = get_statfs_field(path, field).trim().to_owned();
+    match field_str.parse::<u64>() {
+        Err(e) => panic!(
+            "Failed to parse statfs {:?} field ({}): {}",
+            field, field_str, e
+        ),
+        Ok(v) => v,
+    }
+}
+
+#[test]
+fn filesystem_block_size() {
+    let block_size = get_statfs_u64_field("/", StatfsField::FundamentalBlockSize);
+    test_query_ok(r#"<path("/").<filesystem.<block_size"#, json!(block_size));
+}
+
+#[test]
+fn filesystem_blocks() {
+    let blocks = get_statfs_u64_field("/", StatfsField::TotalBlocks);
+    test_query_ok(r#"<path("/").<filesystem.<blocks"#, json!(blocks));
+}
+
+// Ignore this test because the number of available blocks may change between the time we read
+// using stat(1) and the time we run the query.
+#[ignore]
+#[test]
+fn filesystem_blocks_available() {
+    let blocks_available = get_statfs_u64_field("/", StatfsField::AvailableBlocks);
+    test_query_ok(
+        r#"<path("/").<filesystem.<blocks_available"#,
+        json!(blocks_available),
+    );
+}
+
+// Ignore this test because the number of available blocks may change between the time we read
+// using stat(1) and the time we run the query.
+#[ignore]
+#[test]
+fn filesystem_blocks_used() {
+    let blocks = get_statfs_u64_field("/", StatfsField::TotalBlocks);
+    let blocks_available = get_statfs_u64_field("/", StatfsField::AvailableBlocks);
+    let blocks_used = blocks - blocks_available;
+    test_query_ok(r#"<path("/").<filesystem.<blocks_used"#, json!(blocks_used));
+}
+
+#[test]
+fn filesystem_blocks_used_plus_available_is_total() {
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
+    struct BlockInfo {
+        blocks_used: u64,
+        blocks_available: u64,
+        blocks: u64,
+    }
+    let ret = get_query_as::<BlockInfo>(
+        r#"<path("/").<filesystem { blocks_used blocks_available blocks }"#,
+    );
+    assert_eq!(ret.blocks, ret.blocks_used + ret.blocks_available);
+}
+
+#[test]
+fn filesystem_size() {
+    let blocks = get_statfs_u64_field("/", StatfsField::TotalBlocks);
+    let block_size = get_statfs_u64_field("/", StatfsField::FundamentalBlockSize);
+    let size = blocks.checked_mul(block_size).unwrap();
+    test_query_ok(r#"<path("/").<filesystem.<size"#, json!(size));
+}
+
+// Ignore this test because the number of available blocks may change between the time we read
+// using stat(1) and the time we run the query.
+#[ignore]
+#[test]
+fn filesystem_space_available() {
+    let blocks_available = get_statfs_u64_field("/", StatfsField::AvailableBlocks);
+    let block_size = get_statfs_u64_field("/", StatfsField::FundamentalBlockSize);
+    let available = blocks_available.checked_mul(block_size).unwrap();
+    test_query_ok(
+        r#"<path("/").<filesystem.<space_available"#,
+        json!(available),
+    );
+}
+
+// Ignore this test because the number of available blocks may change between the time we read
+// using stat(1) and the time we run the query.
+#[ignore]
+#[test]
+fn filesystem_space_used() {
+    let blocks = get_statfs_u64_field("/", StatfsField::TotalBlocks);
+    let blocks_available = get_statfs_u64_field("/", StatfsField::AvailableBlocks);
+    let blocks_used = blocks.checked_sub(blocks_available).unwrap();
+    let block_size = get_statfs_u64_field("/", StatfsField::FundamentalBlockSize);
+    let used = blocks_used.checked_mul(block_size).unwrap();
+    test_query_ok(r#"<path("/").<filesystem.<space_used"#, json!(used));
+}
+
+#[test]
+fn filesystem_space_used_plus_available_is_total() {
+    #[derive(Debug, Deserialize, Eq, PartialEq)]
+    struct SpaceInfo {
+        space_used: u64,
+        space_available: u64,
+        size: u64,
+    }
+    let ret =
+        get_query_as::<SpaceInfo>(r#"<path("/").<filesystem { space_used space_available size }"#);
+    assert_eq!(ret.size, ret.space_used + ret.space_available);
+}
+
+#[test]
+fn filesystem_percent_used() {
+    #[derive(Debug, Deserialize)]
+    struct UsedInfo {
+        space_used: u64,
+        size: u64,
+        percent_used: f64,
+    }
+    let ret =
+        get_query_as::<UsedInfo>(r#"<path("/").<filesystem { space_used size percent_used }"#);
+    approx::assert_ulps_eq!(
+        ret.percent_used,
+        100f64 * (ret.space_used as f64 / ret.size as f64),
+        max_ulps = 10
+    );
+}
+
+#[test]
+fn filesystem_percent_available() {
+    #[derive(Debug, Deserialize)]
+    struct AvailableInfo {
+        space_available: u64,
+        size: u64,
+        percent_available: f64,
+    }
+    let ret = get_query_as::<AvailableInfo>(
+        r#"<path("/").<filesystem { space_available size percent_available }"#,
+    );
+    approx::assert_ulps_eq!(
+        ret.percent_available,
+        100f64 * (ret.space_available as f64 / ret.size as f64),
+        max_ulps = 10
+    );
+}
+
+#[test]
+fn filesystem_percent_used_plus_available_is_100() {
+    #[derive(Debug, Deserialize)]
+    struct PercentInfo {
+        percent_used: f64,
+        percent_available: f64,
+    }
+    let ret =
+        get_query_as::<PercentInfo>(r#"<path("/").<filesystem { percent_used percent_available }"#);
+    approx::assert_ulps_eq!(
+        ret.percent_used + ret.percent_available,
+        100f64,
+        max_ulps = 10,
+    );
+}


### PR DESCRIPTION
Currently there are only methods to get a subset of the info returned by statvfs(3), so this will need expanding, probably with info obtained from libudev.

For #68: Add functionality to get filesystem info.